### PR TITLE
Webapps should copy recursivelly 

### DIFF
--- a/modules/testbed/src/main/assembly/dir.xml
+++ b/modules/testbed/src/main/assembly/dir.xml
@@ -26,7 +26,7 @@
         <include>cfg/context/*.xml</include>
         <include>deploy/*.xml</include>
         <include>log/*</include>
-        <include>webapps/*</include>
+        <include>webapps/**</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
Actually the webapps/\* only copy one level so something like ../webapps/someapp/some.war doesn't get copied.
I changed that to webapps/**
