### PR TITLE
Jetty does not work out the box in the latest version without the doc type header

### DIFF
--- a/modules/jetty/src/main/resources/META-INF/org/jpos/ee/installs/cfg/jetty.xml
+++ b/modules/jetty/src/main/resources/META-INF/org/jpos/ee/installs/cfg/jetty.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
 <!-- 


### PR DESCRIPTION
...g/jetty.xml

Fix for 

java.lang.ClassCastException: java.lang.String cannot be cast to org.eclipse.jetty.xml.XmlParser$Node

as described here

http://permalink.gmane.org/gmane.comp.ide.eclipse.jetty.user/1745
