### PR TITLE
Support pattern for field to be absent in response

### DIFF
--- a/modules/client-simulator/src/main/java/org/jpos/simulator/TestRunner.java
+++ b/modules/client-simulator/src/main/java/org/jpos/simulator/TestRunner.java
@@ -240,6 +240,17 @@ public class TestRunner
                             //return false;
                         }
                     }
+                    else if (value.startsWith("*A")) {
+                        if (m.hasField(i)) {
+                        // To make sure value is not returned for this field
+                        evt.addMessage("field", "[" + i + "] Received:[" + m.getString(i) + "]"
+                                + " Expected: Not to be set");
+                        }
+                        else {
+                            m.unset(i);
+                            expected.unset(i);
+                        }
+                    }                    
                     else if (m.hasField(i) && !m.getString(i).equals(value)) {
                         evt.addMessage("field", "[" + i+ "] Received:[" + m.getString(i) + "]" + " Expected:[" + value + "]");
                        // return false;


### PR DESCRIPTION
Add a a *A pattern, which can be used in the response messages to make sure the field is absent in the response. There are times when a field  should not be echoed back or set in the response. *A will check if the field is present in the response and if it does it will fail the testcase. The optional *O does not provide as much control as needed.
