### PR TITLE
docs: Correct escaping of asciidoc asterisks for the *M and friends opti...

### DIFF
--- a/doc/src/asciidoc/module_client_simulator.adoc
+++ b/doc/src/asciidoc/module_client_simulator.adoc
@@ -197,9 +197,10 @@ write code like this:
    </isomsg>
 -------------------------------
 
-NOTE: The special string **M* can be used to check for mandatory field
+NOTE: The special string \**M* can be used to check for mandatory field
 presence, regardless its content. Likewise, **E* can be used to check
-for mandatory echo and **O* can be used to check for optional echo.
+for mandatory echo, and \**O* can be used to check for optional echo. You
+can also use **A* to check for mandatory _absence_ of a field.
 
 Test cases supports a count attribute that can be used to fire the same
 test n times.


### PR DESCRIPTION
...ons of the client simulator. Also included the mention of *A which was implemented but not explained.

  Note1: Don't even try to understand why you have to alternate those backslashes. It's very weird and it involved a lot of trial and error!!
  Note2: I left the mention of *O which is NOT implemented in TestRunner. I'll try to do that later.
  [ci skip]