### PR TITLE
Update VariableFieldPackager.java

### DIFF
--- a/modules/fsdmsgx/src/main/java/org/jpos/fsdpackager/VariableFieldPackager.java
+++ b/modules/fsdmsgx/src/main/java/org/jpos/fsdpackager/VariableFieldPackager.java
@@ -76,7 +76,7 @@ public class VariableFieldPackager extends AFSDFieldPackager {
 					delimiter.byteValue(), maxSize));
 		}
 		setValue(value);
-		return i - offset + 1;
+		return i + 1;
 	}
 
 	@Override


### PR DESCRIPTION
The return value was already offsetted in the beginning of the unpack method, removed incorrect offset decrement.