### PR TITLE
Use the header in the response instead of a null

### DIFF
--- a/modules/client-simulator/src/main/java/org/jpos/simulator/TestRunner.java
+++ b/modules/client-simulator/src/main/java/org/jpos/simulator/TestRunner.java
@@ -279,7 +279,7 @@ public class TestRunner
         ISOMsg c = (ISOMsg) tc.getResponse().clone();
         ISOMsg expected = (ISOMsg) tc.getExpectedResponse().clone();
         ISOMsg er = (ISOMsg) tc.getExpandedRequest().clone();
-        c.setHeader ((ISOHeader) null);
+        c.setHeader(tc.getResponse().getHeader());
         if (!processResponse(er, c, expected, bsh, evt)) {
             tc.setResultCode (TestCase.FAILURE);
             return false;


### PR DESCRIPTION
Related to email in jpos user group

https://groups.google.com/d/msg/jpos-users/e1I25Za0NzI/JNTsM9QsCgAJ
TestCase was failing even though the response and expected response were correct. The header handling was incorrect in the code.

User : Edward Mallia made the change and has indicated it works for him.