### PR TITLE
Add Oracle Maven repo for com.sleepycat:je dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ subprojects {
     repositories {
         mavenCentral()
         maven { url 'http://jpos.org/maven' }
+        maven { url 'http://download.oracle.com/maven' }
         mavenLocal()
     }
 


### PR DESCRIPTION
After doing some local jPOS work and changing the version name for my jPOS dependency, jPOS-EE didn't build anymore, complaining about not finding sleepycat (even though it was there in my local cache!)
After a while, I noticed that sleepycat is now hosted at Oracle, and jPOS' build.gradle made the change, but jPOS-EE's build gradle didn't.

Adding the Oracle Maven repo also to jPOS-EE "fixed it" (I hate not understading why or how, and all the repo magic, but I guess this won't break anything :-) )