### PR TITLE
Allow configuring db username and/or password via qbean configuration file that can be encrypted

### DIFF
--- a/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
@@ -37,6 +37,8 @@ import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
 import org.jpos.core.ConfigurationException;
 import org.jpos.ee.support.ModuleUtils;
+import org.jpos.space.Space;
+import org.jpos.space.SpaceFactory;
 import org.jpos.util.Log;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
@@ -480,6 +482,16 @@ public class DB implements Closeable
                 ssrb.applySetting((String) entry.getKey(), entry.getValue());
             }
         }
+
+        // if DBInstantiator has put db user name and/or password in Space, set Hibernate config accordingly
+        Space sp = SpaceFactory.getSpace("tspace:dbconfig");
+        String user = (String) sp.inp("connection.username");
+        String pass = (String) sp.inp("connection.password");
+        if (user != null)
+            ssrb.applySetting("hibernate.connection.username", user);
+        if (pass != null)
+            ssrb.applySetting("hibernate.connection.password", pass);
+
         MetadataSources mds = new MetadataSources(ssrb.build());
         List<String> moduleConfigs = ModuleUtils.getModuleEntries(MODULES_CONFIG_PATH);
         for (String moduleConfig : moduleConfigs) {

--- a/modules/dbsupport/src/main/java/org/jpos/ee/DBInstantiator.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/DBInstantiator.java
@@ -1,6 +1,6 @@
 /*
  * jPOS Project [http://jpos.org]
- * Copyright (C) 2000-2016 Alejandro P. Revilla
+ * Copyright (C) 2000-2017 Alejandro P. Revilla
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/modules/dbsupport/src/main/java/org/jpos/ee/DBInstantiator.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/DBInstantiator.java
@@ -1,0 +1,47 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2016 Alejandro P. Revilla
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.ee;
+
+import org.jpos.q2.QBeanSupport;
+import org.jpos.space.Space;
+import org.jpos.space.SpaceFactory;
+
+/**
+ * @author Sumeet Phadnis
+ *          <p>
+ *          Simple wrapper to instantiate DB class.
+ *          It picks up db user name and password from configuration and puts that in Space.
+ *          DB reads these values from the Space and sets Hibernate configuration properties accordingly.
+ *          Being a qbean its deploy file can be encrypted using Q2.
+ */
+@SuppressWarnings({"UnusedDeclaration"})
+public class DBInstantiator extends QBeanSupport {
+    public void initService() throws Exception {
+        super.initService();
+        Space sp = SpaceFactory.getSpace("tspace:dbconfig");
+        String usr = cfg.get("dbuser", "UNKNOWN");
+        String pswd = cfg.get("dbpass", "UNKNOWN");
+        sp.out("connection.username", usr);
+        sp.out("connection.password", pswd);
+        new org.jpos.ee.DB(cfg.get("config-modifiler"));
+    }
+    public void startService() throws Exception {
+        super.startService();
+    }
+}

--- a/modules/dbsupport/src/main/resources/META-INF/q2/installs/deploy/01_db.xml
+++ b/modules/dbsupport/src/main/resources/META-INF/q2/installs/deploy/01_db.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<qbean name="init-db" class="org.jpos.ee.DBInstantiator" logger="Q2">
+    <property name="dbuser" value="jpos" />
+    <property name="dbpass" value="jpos" />
+</qbean>

--- a/modules/dbsupport/src/main/resources/META-INF/q2/installs/deploy/01_db.xml
+++ b/modules/dbsupport/src/main/resources/META-INF/q2/installs/deploy/01_db.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<qbean name="init-db" class="org.jpos.ee.DBInstantiator" logger="Q2">
+<protect>
+<initdb name="init-db" class="org.jpos.ee.DBInstantiator" logger="Q2">
     <property name="dbuser" value="jpos" />
     <property name="dbpass" value="jpos" />
-</qbean>
+</initdb>
+</protect>
+


### PR DESCRIPTION
Steps to encrypt file:
* Shutdown the application
* Delete `deploy/01_initdb.xml` file, if it exists
* Copy the sample `01_db.xml` to application directory, edit username and password
* Run `bin/q2 -e01_db.xml`

This will create `deploy/01_initdb.xml` file with encrypted data and run the application. Remember to remove the `01_db.xml` file from the application directory!
