### PR TITLE
Sorting not needed for size()

### DIFF
--- a/modules/qi-core/src/main/java/org/jpos/qi/EntityContainer.java
+++ b/modules/qi-core/src/main/java/org/jpos/qi/EntityContainer.java
@@ -240,7 +240,7 @@ public class EntityContainer<T>
         if (size == null) {
             try {
                 size = (Long) DB.exec((db) -> {
-                    Criteria crit = getCriteria(db);
+                    Criteria crit = getBaseCriteria(db);
                     if (searchRestrictions != null && searchRestrictions.size() > 0) {
                         for (Criterion c : searchRestrictions) {
                             crit.add(c);


### PR DESCRIPTION
Since the size() function returns number of records, sorting is not needed. Oracle database does not allow sorting on expressions that are not part of GROUP BY.