### PR TITLE
Added support for multiple session factories in DBInstantiator

### DIFF
--- a/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
@@ -498,8 +498,8 @@ public class DB implements Closeable {
 
         // if DBInstantiator has put db user name and/or password in Space, set Hibernate config accordingly
         Space sp = SpaceFactory.getSpace("tspace:dbconfig");
-        String user = (String) sp.inp("connection.username");
-        String pass = (String) sp.inp("connection.password");
+        String user = (String) sp.inp(dbPropertiesPrefix +"connection.username");
+        String pass = (String) sp.inp(dbPropertiesPrefix +"connection.password");
         if (user != null)
             ssrb.applySetting("hibernate.connection.username", user);
         if (pass != null)

--- a/modules/dbsupport/src/main/java/org/jpos/ee/DBInstantiator.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/DBInstantiator.java
@@ -35,11 +35,11 @@ public class DBInstantiator extends QBeanSupport {
     public void initService() throws Exception {
         super.initService();
         Space sp = SpaceFactory.getSpace("tspace:dbconfig");
-        String usr = cfg.get("dbuser", "UNKNOWN");
-        String pswd = cfg.get("dbpass", "UNKNOWN");
-        sp.out("connection.username", usr);
-        sp.out("connection.password", pswd);
-        new org.jpos.ee.DB(cfg.get("config-modifiler"));
+        String cm = cfg.get("config-modifiler", null);
+        String dbprefix = (cm != null ? cm.split(":")[0] + ":" : "");
+        sp.out(dbprefix + "connection.username", cfg.get("dbuser", "UNKNOWN"));
+        sp.out(dbprefix + "connection.password", cfg.get("dbpass", "UNKNOWN"));
+        new org.jpos.ee.DB(cm);
     }
     public void startService() throws Exception {
         super.startService();


### PR DESCRIPTION
This is done to extend recent support of multiple session factories (based on config-modifiers) in DB class to DBInstantiator class. Login credentials are prefixed with a value derived from config-modifier property in the same manner as in DB class