### PR TITLE
Skip BinLog Tests on MS Windows Platforms

### DIFF
--- a/modules/binlog/src/test/java/org/jpos/binlog/BinLogTest.java
+++ b/modules/binlog/src/test/java/org/jpos/binlog/BinLogTest.java
@@ -22,6 +22,8 @@ package org.jpos.binlog;
 import org.jpos.iso.ISOUtil;
 import org.jpos.util.TPS;
 import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -38,6 +40,11 @@ public class BinLogTest implements Runnable {
     public static File dir;
     private AtomicLong cnt = new AtomicLong();
 
+    @Before
+    public void before () {
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows")); //Skip Tests for BinLog if on MS Windows
+    }
+    
     @BeforeClass
     public static void setup () throws IOException {
         dir = File.createTempFile("binlog-", "");

--- a/modules/binlog/src/test/java/org/jpos/binlog/BinLogTest.java
+++ b/modules/binlog/src/test/java/org/jpos/binlog/BinLogTest.java
@@ -89,10 +89,12 @@ public class BinLogTest implements Runnable {
 
     @AfterClass
     public static void cleanup() throws IOException {
-        for (File f : dir.listFiles()) {
-            if (f.toString().endsWith(".dat")) {
-                System.out.println ("Deleting " + f.toString());
-                f.delete();
+        if (dir.listFiles() != null) {
+            for (File f : dir.listFiles()) {
+                if (f.toString().endsWith(".dat")) {
+                    System.out.println ("Deleting " + f.toString());
+                    f.delete();
+                }
             }
         }
         System.out.println ("Deleting " + dir);


### PR DESCRIPTION
In discussions with APR - Binlog was intended for *nix platforms - MS Windows has different file locking considerations that complicates changes that could impact original intent- as I'm interested in making sure that JPOS-EE compiles and tests cleanly in my Daily MS-Windows CI project in TeamCity and want to ignore Binlog tests on the Windows Platform.