### PR TITLE
Add System user.name as GLUser to support MiniGL Export Test

### DIFF
--- a/modules/minigl/src/test/java/org/jpos/gl/AddExportUserTest.java
+++ b/modules/minigl/src/test/java/org/jpos/gl/AddExportUserTest.java
@@ -1,0 +1,62 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2017 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.gl;
+
+import junit.framework.TestCase;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.HibernateException;
+import org.hibernate.Query;
+import org.jpos.ee.DB;
+import org.jpos.gl.*;
+import java.util.Arrays;
+import java.util.List;
+
+public class AddExportUserTest extends TestCase {
+    public void testAddExportUser() throws Exception {     
+        Session sess = new DB().open();
+        try {
+            GLUser user = getUser(sess,System.getProperty("user.name"));
+        } catch (IllegalArgumentException e) {
+            Transaction txn = sess.beginTransaction();
+            GLUser user = new GLUser();
+            user.setName(System.getProperty ("user.name"));
+            user.setNick(System.getProperty ("user.name"));
+            List<String> perms = Arrays.asList("read","write","grant");
+            perms.forEach(p -> {sess.save (new GLPermission (p)); user.grant (new GLPermission (p));});
+            sess.save (user);
+            txn.commit();
+        }
+        sess.close ();
+    }
+
+    private GLUser getUser (Session session, String nick) 
+        throws HibernateException
+    {
+        Query q = session.createQuery ("from GLUser u where u.nick=:nick");
+        q.setParameter ("nick", nick);
+        List l = q.list();
+        if (l.size() == 0) {
+            throw new IllegalArgumentException (
+                "Invalid nick '" + nick + "'"
+            );
+        }
+        return (GLUser) l.get(0);
+    }
+}

--- a/modules/minigl/src/test/java/org/jpos/gl/AllTests.java
+++ b/modules/minigl/src/test/java/org/jpos/gl/AllTests.java
@@ -26,6 +26,7 @@ public class AllTests {
     public static Test suite() {
         TestSuite suite = new TestSuite();
         suite.addTest (new TestSuite (ImportTest.class));
+        suite.addTest (new TestSuite (AddExportUserTest.class));
         suite.addTest (new TestSuite (CurrencyTest.class));
         suite.addTest (new TestSuite (PermissionTest.class));
         suite.addTest (new TestSuite (ExportTest.class));


### PR DESCRIPTION
The MiniGL Export Test fails unless the user is located in modules/minigl/testdata.xml - This test will add that user to support the Export test if required.