### PR TITLE
ManagerSupport now DBManager

### DIFF
--- a/modules/dbsupport/src/main/java/org/jpos/ee/DBManager.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/DBManager.java
@@ -23,29 +23,25 @@ import org.hibernate.query.criteria.internal.OrderImpl;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
 import javax.persistence.criteria.*;
-import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Created by jr on 6/6/17.
- */
-public class ManagerSupport<T> {
+public class DBManager<T> {
 
     protected DB db;
     private Class<T> clazz;
 
-    public ManagerSupport(DB db) {
+    public DBManager(DB db, Class<T> clazz) {
         this.db = db;
-        clazz = (Class<T>) ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
+        this.clazz = clazz;
     }
 
     public int getItemCount()  {
         CriteriaBuilder criteriaBuilder = db.session().getCriteriaBuilder();
         CriteriaQuery<Long> query = criteriaBuilder.createQuery(Long.class);
         Root<T> root = query.from(clazz);
-        Predicate[] predicates = buildPredicates(root);
+        Predicate[] predicates = buildFilters(root);
         if (predicates != null)
             query.where(predicates);
         query.select(criteriaBuilder.count(root));
@@ -64,7 +60,7 @@ public class ManagerSupport<T> {
                 orderList.add(order);
             }
         }
-        Predicate[] predicates = buildPredicates(root);
+        Predicate[] predicates = buildFilters(root);
         if (predicates != null)
             query.where(predicates);
         query.select(root);
@@ -108,7 +104,7 @@ public class ManagerSupport<T> {
         Predicate equals = criteriaBuilder.equal(root.get(param), value);
         query.where(equals);
         if (withFilter) {
-            Predicate[] predicates = buildPredicates(root);
+            Predicate[] predicates = buildFilters(root);
             if (predicates != null) {
                 //overrides previous predicates
                 query.where(criteriaBuilder.and(criteriaBuilder.and(predicates), equals));
@@ -118,6 +114,6 @@ public class ManagerSupport<T> {
         return query;
     }
 
-    protected Predicate[] buildPredicates(Root<T> root) { return null; }
+    protected Predicate[] buildFilters(Root<T> root) { return null; }
 
 }

--- a/modules/eeuser/src/main/java/org/jpos/ee/ConsumerManager.java
+++ b/modules/eeuser/src/main/java/org/jpos/ee/ConsumerManager.java
@@ -19,23 +19,22 @@
 package org.jpos.ee;
 
 import org.hibernate.HibernateException;
-import org.hibernate.criterion.Restrictions;
 
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.util.*;
 
 @SuppressWarnings("unused")
-public class ConsumerManager extends ManagerSupport<Consumer> {
+public class ConsumerManager extends DBManager<Consumer> {
 
     private User user;
 
     public ConsumerManager (DB db) {
-        super(db);
+        super(db,Consumer.class);
     }
 
     public ConsumerManager(DB db, User user) {
-        super(db);
+        super(db,Consumer.class);
         this.user = user;
     }
 
@@ -50,7 +49,7 @@ public class ConsumerManager extends ManagerSupport<Consumer> {
         return getAll();
     }
 
-    protected Predicate[] buildPredicates(Root<Consumer> root) {
+    protected Predicate[] buildFilters(Root<Consumer> root) {
         Predicate notDeleted = db.session.getCriteriaBuilder().isFalse(root.get("deleted"));
         if (user != null) {
             Predicate p = db.session().getCriteriaBuilder().equal(root.get("user"),user.getId());

--- a/modules/eeuser/src/main/java/org/jpos/ee/RevisionManager.java
+++ b/modules/eeuser/src/main/java/org/jpos/ee/RevisionManager.java
@@ -34,10 +34,10 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
 @SuppressWarnings("unused")
-public class RevisionManager extends ManagerSupport<Revision> {
+public class RevisionManager extends DBManager<Revision> {
 
     public RevisionManager (DB db) {
-        super(db);
+        super(db,Revision.class);
     }
     @SuppressWarnings("unchecked")
     public List<Revision> getRevisionsByRef (String ref)

--- a/modules/eeuser/src/main/java/org/jpos/ee/RoleManager.java
+++ b/modules/eeuser/src/main/java/org/jpos/ee/RoleManager.java
@@ -18,10 +18,10 @@
 
 package org.jpos.ee;
 
-public class RoleManager extends ManagerSupport<Role> {
+public class RoleManager extends DBManager<Role> {
 
     public RoleManager (DB db) {
-        super(db);
+        super(db,Role.class);
     }
 
     public Role getRoleByName (String name) {

--- a/modules/eeuser/src/main/java/org/jpos/ee/UserManager.java
+++ b/modules/eeuser/src/main/java/org/jpos/ee/UserManager.java
@@ -21,17 +21,12 @@ package org.jpos.ee;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.encoders.Base64;
-import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
-import org.hibernate.criterion.Restrictions;
-import org.hibernate.query.criteria.internal.OrderImpl;
 import org.jpos.iso.ISOUtil;
 import org.jpos.security.SystemSeed;
 
@@ -42,7 +37,7 @@ import javax.persistence.criteria.*;
 /**
  * @author Alejandro Revilla
  */
-public class UserManager extends ManagerSupport<User> {
+public class UserManager extends DBManager<User> {
 
     VERSION version;
 
@@ -51,7 +46,7 @@ public class UserManager extends ManagerSupport<User> {
     }
 
     public UserManager (DB db, VERSION version) {
-        super (db);
+        super (db, User.class);
         this.version = version;
     }
 
@@ -92,7 +87,7 @@ public class UserManager extends ManagerSupport<User> {
     }
 
     @Override
-    protected Predicate[] buildPredicates(Root<User> root) {
+    protected Predicate[] buildFilters(Root<User> root) {
         return new Predicate[] {
                 db.session().getCriteriaBuilder().isFalse(root.get("deleted"))
         };

--- a/modules/qi-minigl/src/main/java/org/jpos/qi/minigl/AccountManager.java
+++ b/modules/qi-minigl/src/main/java/org/jpos/qi/minigl/AccountManager.java
@@ -20,7 +20,7 @@ package org.jpos.qi.minigl;
 
 import org.hibernate.query.criteria.internal.OrderImpl;
 import org.jpos.ee.DB;
-import org.jpos.ee.ManagerSupport;
+import org.jpos.ee.DBManager;
 import org.jpos.gl.Account;
 import org.jpos.gl.CompositeAccount;
 
@@ -32,11 +32,11 @@ import java.util.Map;
 /**
  * Created by jr on 8/8/17.
  */
-public class AccountManager extends ManagerSupport<Account> {
+public class AccountManager extends DBManager<Account> {
     
     
     public AccountManager(DB db) {
-        super(db);
+        super(db,Account.class);
     }
 
     public List<Account> getAllChildren(int offset, int limit, Map<String,Boolean> orders, Account parent) throws Exception {

--- a/modules/qi-minigl/src/main/java/org/jpos/qi/minigl/GLTransactionManager.java
+++ b/modules/qi-minigl/src/main/java/org/jpos/qi/minigl/GLTransactionManager.java
@@ -19,32 +19,32 @@
 package org.jpos.qi.minigl;
 
 import org.jpos.ee.DB;
-import org.jpos.ee.ManagerSupport;
+import org.jpos.ee.DBManager;
 import org.jpos.gl.GLTransaction;
 
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.util.Date;
 
-public class GLTransactionManager extends ManagerSupport<GLTransaction> {
+public class GLTransactionManager extends DBManager<GLTransaction> {
 
    private Date start;
    private Date end;
    private Long journalId;
 
     public GLTransactionManager(DB db) {
-        super(db);
+        super(db,GLTransaction.class);
     }
 
     public GLTransactionManager(DB db, Long journalId, Date start, Date end) {
-        super(db);
+        super(db,GLTransaction.class);
         this.start = start;
         this.end = end;
         this.journalId = journalId;
     }
 
     @Override
-    protected Predicate[] buildPredicates(Root<GLTransaction> root) {
+    protected Predicate[] buildFilters(Root<GLTransaction> root) {
         db.session().enableFetchProfile("eager");
         Predicate journalPredicate = null;
         if (journalId != null) {

--- a/modules/sysconfig/src/main/java/org/jpos/ee/SysConfigManager.java
+++ b/modules/sysconfig/src/main/java/org/jpos/ee/SysConfigManager.java
@@ -30,14 +30,14 @@ import org.hibernate.type.IntegerType;
 import javax.persistence.criteria.*;
 
 @SuppressWarnings("unused")
-public class SysConfigManager extends ManagerSupport<SysConfig> {
+public class SysConfigManager extends DBManager<SysConfig> {
     private String prefix = "";
 
     public SysConfigManager (DB db) {
-        super(db);
+        super(db,SysConfig.class);
     }
     public SysConfigManager (DB db, String prefix) {
-        super(db);
+        super(db,SysConfig.class);
         this.prefix = prefix;
     }
     public void setPrefix (String prefix) {
@@ -130,7 +130,7 @@ public class SysConfigManager extends ManagerSupport<SysConfig> {
     }
 
     @Override
-    protected Predicate[] buildPredicates(Root<SysConfig> root) {
+    protected Predicate[] buildFilters(Root<SysConfig> root) {
         Predicate[] predicates = new Predicate[] {
             db.session().getCriteriaBuilder().like(root.get("id"),prefix + "%")
         };

--- a/modules/syslog/src/main/java/org/jpos/ee/SysLogManager.java
+++ b/modules/syslog/src/main/java/org/jpos/ee/SysLogManager.java
@@ -26,7 +26,7 @@ import org.hibernate.Transaction;
 
 
 @SuppressWarnings("unused")
-public class SysLogManager extends ManagerSupport<SysLog> {
+public class SysLogManager extends DBManager<SysLog> {
     boolean autoCommit;
 
     /**
@@ -34,7 +34,7 @@ public class SysLogManager extends ManagerSupport<SysLog> {
      * (open/begin/commit/close is not required).
      */
     public SysLogManager () {
-        super (new DB());
+        super (new DB(),SysLog.class);
         autoCommit = true;
     }
 
@@ -45,7 +45,7 @@ public class SysLogManager extends ManagerSupport<SysLog> {
      * @param db the DB instance
      */
     public SysLogManager (DB db) {
-        super(db);
+        super(db,SysLog.class);
         autoCommit = false;
     }
 
@@ -55,7 +55,7 @@ public class SysLogManager extends ManagerSupport<SysLog> {
      * @param autoCommit true if we want this manager to auto-commit log events
      */
     public SysLogManager (DB db, boolean autoCommit) {
-        super(db);
+        super(db, SysLog.class);
         this.autoCommit = autoCommit;
     }
 


### PR DESCRIPTION
DBManager constructor now needs class.
Changes name of buildPredicates() to buildFilters()
Changes on other Managers to adapt to this.