### PR TITLE
Implement TriggerListener

### DIFF
--- a/modules/quartz/src/main/java/org/jpos/q2/QuartzAdaptor.java
+++ b/modules/quartz/src/main/java/org/jpos/q2/QuartzAdaptor.java
@@ -27,7 +27,19 @@ import org.jpos.util.LogEvent;
 import org.jpos.util.LogSource;
 import org.jpos.util.Logger;
 import org.jpos.util.NameRegistrar;
-import org.quartz.*;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.Trigger.CompletedExecutionInstruction;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerListener;
 import org.quartz.impl.StdSchedulerFactory;
 
 import java.util.Date;
@@ -35,7 +47,7 @@ import java.util.Properties;
 import java.util.UUID;
 
 @SuppressWarnings("unused unchecked")
-public class QuartzAdaptor extends QBeanSupport implements XmlConfigurable {
+public class QuartzAdaptor extends QBeanSupport implements XmlConfigurable, TriggerListener {
     private Scheduler scheduler;
     private Element config;
     protected void initService() throws Exception {
@@ -68,6 +80,7 @@ public class QuartzAdaptor extends QBeanSupport implements XmlConfigurable {
                 trigger = TriggerBuilder.newTrigger()
                         .withIdentity(e.getAttributeValue("id"), getName())
                         .withSchedule(CronScheduleBuilder.cronSchedule(e.getAttributeValue("when")))
+                        .withMisfireHandlingInstructionFireAndProceed())
                         .build();
 
                 Date ft = scheduler.scheduleJob(job, trigger);
@@ -152,4 +165,36 @@ public class QuartzAdaptor extends QBeanSupport implements XmlConfigurable {
 
         return new StdSchedulerFactory(p).getScheduler();
     }
+    
+    @Override
+    public void triggerFired(Trigger trigger, JobExecutionContext context) {
+        LogEvent evt = getLog().createInfo();
+        evt.addMessage(getName() + " Trigger Fired and it will fire again at " + trigger.getNextFireTime() + "  "
+                + context.getJobDetail());
+        Logger.log(evt);
+
+    }
+
+    @Override
+    public boolean vetoJobExecution(Trigger trigger, JobExecutionContext context) {
+        return false;
+    }
+
+    @Override
+    public void triggerMisfired(Trigger trigger) {
+        LogEvent evt = getLog().createInfo();
+        evt.addMessage(getName() + " Trigger Mis-Fired and will fire again at " + trigger.getNextFireTime());
+        Logger.log(evt);
+
+    }
+
+    @Override
+    public void triggerComplete(Trigger trigger, JobExecutionContext context,
+            CompletedExecutionInstruction triggerInstructionCode) {
+        LogEvent evt = getLog().createInfo();
+        evt.addMessage("Trigger completed. " + context.getJobDetail());
+        Logger.log(evt);
+
+    }
+
 }


### PR DESCRIPTION
At times its possible trigger doesn't fire (quartz calls it mis-fire)and we need to log it else we may just not know when a job isn't performed.
Mis-fire handling instructions need to be provided at trigger creation time (withMisfireHandlingInstructionFireAndProceed).
Also helpful to log when the trigger is fired and completed(part of TriggerListener implementation) along with info when it will get triggered again.