### PR TITLE
Java 10 JDK Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,10 @@ subprojects {
 
     dependencies {
         testCompile libraries.junit
+        //Java 10 support
+        testCompile('com.sun.xml.bind:jaxb-impl:2.1.2')
+        testCompile('com.sun.activation:javax.activation:1.2.0')
+        testCompile('javax.xml.bind:jaxb-api:2.3.0')
     }
 
     task allDeps(type: DependencyReportTask) {}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-rc-2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Tested succesful `gradlew clean build` on both java 8 and java 10 JDK's

Uses Java 8 language features

Includes java.xml.bind and javax.activation modules dependencies. This step is required because those modules are deprecated and will be removed by JEP-320 that is scheduled to be released with JDK 11

Upgraded Gradle Wrapper to remove warnings - see https://github.com/gradle/gradle/issues/5529