### PR TITLE
Fix gradle deprecation warnings.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'signing'
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -50,7 +50,7 @@ subprojects {
             url 'https://jpos.org/issues'
         }
         scm {
-            url "http://github.com/jpos/jPOS"
+            url "https://github.com/jpos/jPOS"
             connection "scm:git:https://github.com/jpos/jPOS-EE.git"
             developerConnection "scm:git:git@github.com:jpos/jPOS-EE.git"
         }
@@ -97,7 +97,7 @@ subprojects {
     }
     task sourceJar(type: Jar) {
         from sourceSets.main.allSource
-        classifier = 'sources'
+        archiveClassifier.set('sources')
     }
 
     artifacts {
@@ -106,9 +106,9 @@ subprojects {
 
     repositories {
         mavenCentral()
-        maven { url 'http://jpos.org/maven' }
-        maven { url 'http://download.oracle.com/maven' }
-        maven { url 'http://maven.vaadin.com/vaadin-addons' }
+        maven { url 'https://jpos.org/maven' }
+        maven { url 'https://download.oracle.com/maven' }
+        maven { url 'https://maven.vaadin.com/vaadin-addons' }
         maven { url 'https://maven.vaadin.com/vaadin-prereleases' }
         jcenter()
         mavenLocal()
@@ -117,16 +117,16 @@ subprojects {
     dependencies {
         testImplementation libraries.junit
         //Java 10 support
-        testCompile('com.sun.xml.bind:jaxb-impl:2.1.2')
-        testCompile('com.sun.activation:javax.activation:1.2.0')
-        testCompile('javax.xml.bind:jaxb-api:2.3.0')
+        testImplementation('com.sun.xml.bind:jaxb-impl:2.1.2')
+        testImplementation('com.sun.activation:javax.activation:1.2.0')
+        testImplementation('javax.xml.bind:jaxb-api:2.3.0')
     }
 
     task allDeps(type: DependencyReportTask) {}
 }
 
 task allSources(type: Jar,dependsOn: subprojects.assemble) {
-    baseName = 'jposee-sources'
+    archiveBaseName = 'jposee-sources'
     from subprojects.collect { project ->
         project.sourceSets.main.allSource
     }

--- a/jpos-app.gradle
+++ b/jpos-app.gradle
@@ -64,11 +64,12 @@ def jposCopySpec = copySpec {
 
 // Create the jar's manifest
 jar.manifest {
-    attributes \
+    attributes(
         'Implementation-Title': project.name,
         'Implementation-Version': project.version,
         'Main-Class': 'org.jpos.q2.Q2',
-        'Class-Path': configurations.runtime.collect { "lib/" + it.getName() }.join(' ')
+        'Class-Path': configurations.runtimeClasspath.files.collect { "lib/" + it.getName() }.join(' ')
+    )
 }
 
 processResources {
@@ -97,10 +98,10 @@ task version (type: JavaExec, dependsOn: classes) {
 
 task dist(type: Tar) {
     description 'Creates tar distribution'
-    into "$project.name-$version"
+    into "$project.name-$archiveVersion"
     with jposCopySpec
     compression = Compression.GZIP
-    extension "tar.gz"
+    archiveExtension = "tar.gz"
 }
 
 task installApp(type: Sync) {

--- a/modules/binlog-quartz/build.gradle
+++ b/modules/binlog-quartz/build.gradle
@@ -1,7 +1,7 @@
 description = 'jPOS-EE :: BinLog Quartz Module'
 
 dependencies {
-    compile project(':modules:binlog')
-    compile project(':modules:quartz')
+    api project(':modules:binlog')
+    api project(':modules:quartz')
 }
 

--- a/modules/binlog/build.gradle
+++ b/modules/binlog/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: BinLog Module'
 
 dependencies {
-    compile libraries.jpos
+    api libraries.jpos
 }
 

--- a/modules/client-simulator/build.gradle
+++ b/modules/client-simulator/build.gradle
@@ -1,7 +1,7 @@
 description = 'jPOS-EE :: Client Simulator'
 
 dependencies {
-    compile project(':modules:core')
+    api project(':modules:core')
 }
 
 apply from: "${rootProject.projectDir}/jpos-app.gradle"

--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -6,7 +6,7 @@ configurations {
 }
 
 dependencies {
-    compile libraries.jpos
-    compile libraries.joda_time
+    api libraries.jpos
+    api libraries.joda_time
 }
 

--- a/modules/cryptoserver/build.gradle
+++ b/modules/cryptoserver/build.gradle
@@ -1,12 +1,12 @@
 description = 'jPOS-EE :: Crypto Server'
 
 dependencies {
-    testCompile libraries.junit
-    testCompile libraries.restAssured
-    compile project(':modules:qrest')
-    compile project(':modules:cryptoservice')
-    compile project(':modules:db-mysql')
-    compile project(':modules:logback')
+    testImplementation libraries.junit
+    testImplementation libraries.restAssured
+    api project(':modules:qrest')
+    api project(':modules:cryptoservice')
+    api project(':modules:db-mysql')
+    api project(':modules:logback')
 }
 
 apply from: "${rootProject.projectDir}/jpos-app.gradle"

--- a/modules/cryptoservice/build.gradle
+++ b/modules/cryptoservice/build.gradle
@@ -1,8 +1,8 @@
 description = 'jPOS-EE :: CryptoService'
 
-dependencies { 
-    compile libraries.jpos
-    compile project(':modules:sysconfig')
+dependencies {
+    api libraries.jpos
+    api project(':modules:sysconfig')
 }
 
 

--- a/modules/db-flyway/build.gradle
+++ b/modules/db-flyway/build.gradle
@@ -1,10 +1,10 @@
 description = 'jPOS-EE :: flyWay support'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    compile project(':modules:db-postgresql')
-    compile project(':modules:logback')
-    compile libraries.flywaydb
+    api project(':modules:dbsupport')
+    api project(':modules:db-postgresql')
+    api project(':modules:logback')
+    implementation libraries.flywaydb
 }
 
 apply from: "${rootProject.projectDir}/jpos-app.gradle"

--- a/modules/db-h2/build.gradle
+++ b/modules/db-h2/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: H2 DB support'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    compile libraries.jdbcH2
+    api project(':modules:dbsupport')
+    implementation libraries.jdbcH2
 }

--- a/modules/db-mssql/build.gradle
+++ b/modules/db-mssql/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: Microsoft SQL Server support'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    compile libraries.jdbcMssql
+    api project(':modules:dbsupport')
+    implementation libraries.jdbcMssql
 }

--- a/modules/db-mysql/build.gradle
+++ b/modules/db-mysql/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: MySql support'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    compile libraries.jdbcMysql
+    api project(':modules:dbsupport')
+    implementation libraries.jdbcMysql
 }

--- a/modules/db-postgresql/build.gradle
+++ b/modules/db-postgresql/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: PostgreSQL support'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    compile libraries.jdbcPostgresql
+    api project(':modules:dbsupport')
+    implementation libraries.jdbcPostgresql
 }

--- a/modules/dbsupport/build.gradle
+++ b/modules/dbsupport/build.gradle
@@ -1,13 +1,13 @@
 description = 'jPOS-EE :: Database Support Module'
 
 dependencies {
-    compile project(':modules:core')
-    compile libraries.hibernate_core
-    compile libraries.hibernate_envers
-    compile libraries.hibernate_c3p0
-    compile libraries.c3p0 // force c3p0 version (temporary fix un Hibernate bumps up version)
-    compile libraries.hibernate_ehcache
-    compile libraries.jta
-    compile libraries.jacksonDatabind
+    api project(':modules:core')
+    api libraries.hibernate_core
+    implementation libraries.hibernate_envers
+    implementation libraries.hibernate_c3p0
+    implementation libraries.c3p0 // force c3p0 version (temporary fix un Hibernate bumps up version)
+    implementation libraries.hibernate_ehcache
+    implementation libraries.jta
+    api libraries.jacksonDatabind
 }
 

--- a/modules/eerest/build.gradle
+++ b/modules/eerest/build.gradle
@@ -1,11 +1,11 @@
 description = 'jPOS-EE :: Rest'
 
 dependencies {
-    compile project(':modules:core')
-    compile project(':modules:txn')
-    compile "javax.ws.rs:javax.ws.rs-api:${jaxrsVersion}"
-    compile jsonSchemaValidatorLibs
-    compile libraries.commons_lang
+    api project(':modules:core')
+    api project(':modules:txn')
+    implementation "javax.ws.rs:javax.ws.rs-api:${jaxrsVersion}"
+    implementation jsonSchemaValidatorLibs
+    implementation libraries.commons_lang
 }
 
 apply from: "${rootProject.projectDir}/jpos-app.gradle"

--- a/modules/eeresttest/build.gradle
+++ b/modules/eeresttest/build.gradle
@@ -10,8 +10,8 @@ dependencies {
     providedCompile 'com.google.guava:guava:27.1-jre' // force newer Guava
     providedCompile "org.glassfish.jersey.media:jersey-media-json-jackson:2.22.1"
     providedCompile "org.glassfish.jersey.core:jersey-server:2.22.1"
-    compile libraries.commons_lang
-    testCompile libraries.restAssured
+    implementation libraries.commons_lang
+    testImplementation libraries.restAssured
     providedCompile "org.glassfish.jersey.containers:jersey-container-servlet:2.22.1"
 }
 

--- a/modules/eeuser/build.gradle
+++ b/modules/eeuser/build.gradle
@@ -1,9 +1,9 @@
 description = 'jPOS-EE :: User Module'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    testCompile project(':modules:db-h2')
-    compile libraries.commons_lang
+    api project(':modules:dbsupport')
+    testImplementation project(':modules:db-h2')
+    api libraries.commons_lang
 }
 
 ext {

--- a/modules/freemarker-decorator/build.gradle
+++ b/modules/freemarker-decorator/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: Freemarker Decorator Module'
 
 dependencies {
-    compile project(':modules:core')
-    compile libraries.freemarker
+    api project(':modules:core')
+    implementation libraries.freemarker
 }

--- a/modules/fsdmsgx/build.gradle
+++ b/modules/fsdmsgx/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: FSDMsgX'
 
 dependencies {
-    compile libraries.jpos
+    api libraries.jpos
 }
 

--- a/modules/groovy/build.gradle
+++ b/modules/groovy/build.gradle
@@ -1,11 +1,11 @@
 description = 'jPOS-EE :: Groovy Module'
 
 dependencies {
-    compile libraries.jpos
-    compile libraries.groovy
-    compile libraries.groovysh
-    compile group: 'org.fusesource.jansi', name: 'jansi', version: '1.11'
+    api libraries.jpos
+    implementation libraries.groovy
+    implementation libraries.groovysh
+    implementation group: 'org.fusesource.jansi', name: 'jansi', version: '1.11'
 
-    compile libraries.groovySql
+    implementation libraries.groovySql
 }
 

--- a/modules/http-client/build.gradle
+++ b/modules/http-client/build.gradle
@@ -1,9 +1,9 @@
 description = 'jPOS-EE :: QRest Client'
 
 dependencies {
-    compile libraries.jpos
-    compile libraries.httpAsyncClient
-    testCompile project(':modules:qrest')
+    api libraries.jpos
+    implementation libraries.httpAsyncClient
+    testImplementation project(':modules:qrest')
 }
 
 apply from: "${rootProject.projectDir}/jpos-app.gradle"

--- a/modules/iso-http-client/build.gradle
+++ b/modules/iso-http-client/build.gradle
@@ -1,10 +1,10 @@
 description = 'jPOS-EE :: ISO over HTTP Client Code'
 
 dependencies {
-    compile libraries.jpos
-    
-    compile "org.eclipse.jetty:jetty-client:${jettyVersion}"
-    compile "org.eclipse.jetty.http2:http2-client:${jettyVersion}"
-    compile "org.eclipse.jetty.http2:http2-http-client-transport:${jettyVersion}"
+    api libraries.jpos
+
+    implementation "org.eclipse.jetty:jetty-client:${jettyVersion}"
+    implementation "org.eclipse.jetty.http2:http2-client:${jettyVersion}"
+    implementation "org.eclipse.jetty.http2:http2-http-client-transport:${jettyVersion}"
 }
 

--- a/modules/iso-http-server/build.gradle
+++ b/modules/iso-http-server/build.gradle
@@ -1,7 +1,7 @@
 description = 'jPOS-EE :: ISO over HTTP Client Code'
 
 dependencies {
-    compile libraries.jpos
-    compile "org.jdom:jdom2:2.0.6"
+    api libraries.jpos
+    implementation "org.jdom:jdom2:2.0.6"
 }
 

--- a/modules/iso-http-servlet/build.gradle
+++ b/modules/iso-http-servlet/build.gradle
@@ -3,10 +3,10 @@ description = 'jPOS-EE :: ISO over HTTP Client Code'
 apply plugin: 'war'
 
 dependencies {
-    compile libraries.jpos
-    compile libraries.servlet_api
-    compile "javax.ws.rs:javax.ws.rs-api:${jaxrsVersion}"
-    compile project(':modules:iso-http-server')
+    api libraries.jpos
+    implementation libraries.servlet_api
+    implementation "javax.ws.rs:javax.ws.rs-api:${jaxrsVersion}"
+    api project(':modules:iso-http-server')
     providedCompile project(':modules:jetty')
 }
 

--- a/modules/jetty/build.gradle
+++ b/modules/jetty/build.gradle
@@ -1,8 +1,8 @@
 description = 'jPOS-EE :: Jetty Web Module'
 
 dependencies {
-    compile project(':modules:core')
-    compile jettyLibs
-    compile "javax.websocket:javax.websocket-api:${websocketApiVersion}"
+    api project(':modules:core')
+    implementation jettyLibs
+    implementation "javax.websocket:javax.websocket-api:${websocketApiVersion}"
 }
 

--- a/modules/logback/build.gradle
+++ b/modules/logback/build.gradle
@@ -1,11 +1,11 @@
 description = 'jPOS-EE :: Logback Support Module'
 
 dependencies {
-    compile project(':modules:core')
-    compile libraries.slf4j_api
-    compile libraries.jcl_over_slf4j
-    compile libraries.log4j_over_slf4j
-    compile libraries.jul_to_slf4j
-    compile libraries.logback
+    api project(':modules:core')
+    implementation libraries.slf4j_api
+    api libraries.jcl_over_slf4j
+    implementation libraries.log4j_over_slf4j
+    implementation libraries.jul_to_slf4j
+    implementation libraries.logback
 }
 

--- a/modules/mail/build.gradle
+++ b/modules/mail/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: Mail support module'
 
 dependencies {
-    compile project(':modules:core')
-    compile libraries.javax_mail
+    api project(':modules:core')
+    implementation libraries.javax_mail
 }

--- a/modules/minigl/build.gradle
+++ b/modules/minigl/build.gradle
@@ -2,10 +2,10 @@
 description = 'jPOS-EE :: MiniGL Module'
 
 dependencies {
-    compile project(':modules:logback')
-    compile project(':modules:dbsupport')
-    compile libraries.commons_lang
-    testCompile project(':modules:db-h2')
+    api project(':modules:logback')
+    api project(':modules:dbsupport')
+    implementation libraries.commons_lang
+    testImplementation project(':modules:db-h2')
 }
 
 ext {

--- a/modules/qi-core/build.gradle
+++ b/modules/qi-core/build.gradle
@@ -56,15 +56,15 @@ install {
 uploadArchives.enabled = false
 
 dependencies {
-    compile "com.vaadin:vaadin-server:${vaadinVersion}"
-    compile "com.vaadin:vaadin-push:${vaadinVersion}"
-    compile 'org.vaadin.addons:d3Gauge:1.0.1'
-    compile 'org.vaadin.addons:dcharts-widget:1.7.0'
-    compile 'com.vaadin:vaadin-context-menu:3.0.0'
-    compile 'com.byteowls:vaadin-chartjs:0.3.0'
-    compile 'org.vaadin.addons:vaadin-sliderpanel:2.0.0'
-    compile "com.vaadin:vaadin-themes:${vaadin.version}"
-    compile 'com.vaadin:vaadin-sass-compiler:0.9.13'
+    implementation "com.vaadin:vaadin-server:${vaadinVersion}"
+    implementation "com.vaadin:vaadin-push:${vaadinVersion}"
+    implementation 'org.vaadin.addons:d3Gauge:1.0.1'
+    implementation 'org.vaadin.addons:dcharts-widget:1.7.0'
+    implementation 'com.vaadin:vaadin-context-menu:3.0.0'
+    implementation 'com.byteowls:vaadin-chartjs:0.3.0'
+    implementation 'org.vaadin.addons:vaadin-sliderpanel:2.0.0'
+    implementation "com.vaadin:vaadin-themes:${vaadin.version}"
+    implementation 'com.vaadin:vaadin-sass-compiler:0.9.13'
 
     providedCompile project(':modules:core')
     providedCompile project(':modules:visitor')

--- a/modules/qi-eeuser/build.gradle
+++ b/modules/qi-eeuser/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile project(':modules:qi-core')
-    compile project(':modules:cryptoservice')
+    api project(':modules:qi-core')
+    api project(':modules:cryptoservice')
 }
 

--- a/modules/qi-minigl/build.gradle
+++ b/modules/qi-minigl/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    compile project(':modules:qi-core')
-    compile project(':modules:minigl')
+    api project(':modules:qi-core')
+    api project(':modules:minigl')
 }

--- a/modules/qi-sysconfig/build.gradle
+++ b/modules/qi-sysconfig/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    compile project(':modules:qi-core')
+    api project(':modules:qi-core')
 }
 

--- a/modules/qrest/build.gradle
+++ b/modules/qrest/build.gradle
@@ -1,14 +1,14 @@
 description = 'jPOS-EE :: QRest'
 
 dependencies {
-    compile libraries.jpos
-    compile libraries.jacksonDatabind
-    compile libraries.nettyHandler
-    compile libraries.nettyCodecHttp
-    compile libraries.freemarker
-    compile jsonSchemaValidatorLibs
-    testCompile libraries.junit
-    testCompile libraries.restAssured
+    api libraries.jpos
+    implementation libraries.jacksonDatabind
+    api libraries.nettyHandler
+    api libraries.nettyCodecHttp
+    implementation libraries.freemarker
+    implementation jsonSchemaValidatorLibs
+    testImplementation libraries.junit
+    testImplementation libraries.restAssured
 }
 
 apply from: "${rootProject.projectDir}/jpos-app.gradle"

--- a/modules/quartz/build.gradle
+++ b/modules/quartz/build.gradle
@@ -1,8 +1,8 @@
 description = 'jPOS-EE :: Quartz integration'
 
-dependencies { 
-    compile libraries.jpos
-    compile (libraries.quartz) {
+dependencies {
+    api libraries.jpos
+    api (libraries.quartz) {
         exclude group: 'c3p0', module: 'c3p0'
     }
 }

--- a/modules/rest-testbed/build.gradle
+++ b/modules/rest-testbed/build.gradle
@@ -3,7 +3,7 @@ description = 'jPOS-EE :: Testbed'
 apply plugin: 'war'
 
 dependencies {
-    compile (libraries.jpos)  {
+    api (libraries.jpos)  {
         exclude(module: 'junit')
         exclude(module: 'hamcrest-core')
     }

--- a/modules/resultcode/build.gradle
+++ b/modules/resultcode/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: Resultcode Module'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    compile libraries.commons_lang
+    api project(':modules:dbsupport')
+    implementation libraries.commons_lang
 }

--- a/modules/rspace/build.gradle
+++ b/modules/rspace/build.gradle
@@ -1,7 +1,7 @@
 description = 'jPOS-EE :: RSpace Module'
 
 dependencies {
-    compile libraries.jpos
-    compile libraries.jgroups
+    api libraries.jpos
+    implementation libraries.jgroups
 }
 

--- a/modules/saf-monitor/build.gradle
+++ b/modules/saf-monitor/build.gradle
@@ -1,7 +1,7 @@
 description = 'jPOS-EE :: Store and Forward (SAF) Monitor Module'
 
 dependencies {
-    compile project(':modules:saf')
-    compile project(':modules:status')
+    api project(':modules:saf')
+    api project(':modules:status')
 }
 

--- a/modules/saf/build.gradle
+++ b/modules/saf/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: Store and Forward (SAF) Module'
 
 dependencies {
-    compile project(':modules:core')
+    api project(':modules:core')
 }
 

--- a/modules/seqno/build.gradle
+++ b/modules/seqno/build.gradle
@@ -1,9 +1,9 @@
 description = 'jPOS-EE :: SeqNo'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    testCompile project(':modules:db-h2')
-    // compile project(':modules:db-mysql')
+    api project(':modules:dbsupport')
+    testImplementation project(':modules:db-h2')
+    // implementation project(':modules:db-mysql')
 }
 
 

--- a/modules/server-simulator/build.gradle
+++ b/modules/server-simulator/build.gradle
@@ -1,5 +1,5 @@
 description = 'jPOS-EE :: Server Simulator'
 
 dependencies {
-    compile project(':modules:core')
+    api project(':modules:core')
 }

--- a/modules/status/build.gradle
+++ b/modules/status/build.gradle
@@ -1,7 +1,7 @@
 description = 'jPOS-EE :: Status Module'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    compile project(':modules:syslog')
-    compile project(':modules:eeuser')
+    api project(':modules:dbsupport')
+    api project(':modules:syslog')
+    api project(':modules:eeuser')
 }

--- a/modules/sysconfig/build.gradle
+++ b/modules/sysconfig/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: Sysconfig Module'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    compile libraries.commons_lang
+    api project(':modules:dbsupport')
+    implementation libraries.commons_lang
 }

--- a/modules/syslog/build.gradle
+++ b/modules/syslog/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: Syslog Module'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    compile libraries.commons_lang
+    api project(':modules:dbsupport')
+    implementation libraries.commons_lang
 }

--- a/modules/things/build.gradle
+++ b/modules/things/build.gradle
@@ -1,6 +1,6 @@
 description = 'jPOS-EE :: Things Module'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    compile libraries.commons_lang
+    api project(':modules:dbsupport')
+    implementation libraries.commons_lang
 }

--- a/modules/txn/build.gradle
+++ b/modules/txn/build.gradle
@@ -1,5 +1,5 @@
 description = 'jPOS-EE :: Txn Module'
 
 dependencies {
-    compile project(':modules:dbsupport')
+    api project(':modules:dbsupport')
 }

--- a/modules/visitor/build.gradle
+++ b/modules/visitor/build.gradle
@@ -1,8 +1,8 @@
 description = 'jPOS-EE :: User Module'
 
 dependencies {
-    compile project(':modules:dbsupport')
-    compile project(':modules:eeuser')
-    compile libraries.servlet_api
+    api project(':modules:dbsupport')
+    api project(':modules:eeuser')
+    implementation libraries.servlet_api
 }
 


### PR DESCRIPTION
This should fix most deprecation warnings emitted by gradle, special care should be taken when reviewing fixes that change `compile` to `implementation` as transient dependencies are not exposed unless `api` is used.