### PR TITLE
New method to get the JChannel initiated by ReplicatedSpace

### DIFF
--- a/modules/rspace/src/main/java/org/jpos/space/ReplicatedSpace.java
+++ b/modules/rspace/src/main/java/org/jpos/space/ReplicatedSpace.java
@@ -622,5 +622,9 @@ public class ReplicatedSpace
         }
         return obj;
     }
+
+    public JChannel getChannel() {
+        return channel;
+    }
 }
 


### PR DESCRIPTION
The JChannel can then be used to access other services provided by JGroups such as LockService