### PR TITLE
provide metamethod equivalents of Caller#info

### DIFF
--- a/modules/groovy/src/main/java/org/jpos/groovy/GroovyRequestListener.java
+++ b/modules/groovy/src/main/java/org/jpos/groovy/GroovyRequestListener.java
@@ -31,6 +31,7 @@ import org.jpos.util.Log;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
 
@@ -147,6 +148,10 @@ public class GroovyRequestListener extends Log
     @Override
     public void setConfiguration(Element e) throws ConfigurationException
     {
+        ClassLoader thisCL= this.getClass().getClassLoader();
+        URL scriptURL= thisCL.getResource("org/jpos/groovy/JPOSGroovyDefaults.groovy");
+        GroovySetup.runScriptOnce(scriptURL);
+
         xmlCfg= e;
 
         script= getScript(e.getChild("script"));

--- a/modules/groovy/src/main/java/org/jpos/q2/qbean/Groovy.java
+++ b/modules/groovy/src/main/java/org/jpos/q2/qbean/Groovy.java
@@ -21,9 +21,11 @@ package org.jpos.q2.qbean;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import org.jdom2.Element;
+import org.jpos.groovy.GroovySetup;
 import org.jpos.q2.QBeanSupport;
 
 import java.io.File;
+import java.net.URL;
 
 /**
  * Groovy Interpreter QBean.
@@ -36,6 +38,10 @@ public class Groovy extends QBeanSupport implements Runnable {
 
     public void run() {
         try {
+            ClassLoader thisCL= this.getClass().getClassLoader();
+            URL scriptURL= thisCL.getResource("org/jpos/groovy/JPOSGroovyDefaults.groovy");
+            GroovySetup.runScriptOnce(scriptURL);
+
             Element e = getPersist();
             Binding binding = new Binding();
             binding.setVariable("qbean", this);

--- a/modules/groovy/src/main/java/org/jpos/transaction/participant/GroovyParticipant.java
+++ b/modules/groovy/src/main/java/org/jpos/transaction/participant/GroovyParticipant.java
@@ -110,7 +110,7 @@ public class GroovyParticipant extends Log
 
     private TransactionManager tm;
     protected Configuration cfg;
-    private final String groovyShellKey  = ".groovy-" + Integer.toString(hashCode());
+    private final String groovyShellKey  = ".groovy-" + hashCode();
 
 
     @SuppressWarnings("unchecked")
@@ -197,7 +197,7 @@ public class GroovyParticipant extends Log
     @Override
     public void setConfiguration(Element e) throws ConfigurationException {
         ClassLoader thisCL= this.getClass().getClassLoader();
-        URL scriptURL= thisCL.getResource("org/jpos/transaction/ContextDefaults.groovy");
+        URL scriptURL= thisCL.getResource("org/jpos/groovy/JPOSGroovyDefaults.groovy");
         GroovySetup.runScriptOnce(scriptURL);
 
         compiled= cfg.getBoolean("compiled", true);

--- a/modules/groovy/src/main/resources/org/jpos/groovy/JPOSGroovyDefaults.groovy
+++ b/modules/groovy/src/main/resources/org/jpos/groovy/JPOSGroovyDefaults.groovy
@@ -18,10 +18,14 @@
 
 package org.jpos.groovy
 
-import org.jpos.transaction.*
+import groovy.transform.CompileStatic
+import groovy.transform.Field
 
-// Groovy initialization to spice up Context object
+import org.jpos.transaction.Context
+import org.jpos.util.Caller
 
+
+// ### Groovy initialization to spice up Context object
 
 def ctxmc= Context.metaClass
 
@@ -42,4 +46,61 @@ ctxmc.putAt= { Object key, Object val ->
     delegate.put(key, val)
 }
 
+
+// ### Groovy alternatives for org.jpos.util.Caller#info() methods
+
+
+// We want to ignore stack elements belonging to these classes
+// This list and the shouldExclude method are inspired by org.codehaus.groovy.runtime.StackTraceUtils.isApplicationClass()
+@Field static final List filter= [
+                "groovy.lang.", "org.codehaus.groovy.", "org.apache.groovy.", "gjdk.groovy.",
+                "sun.reflect.", "java.lang.reflect.",
+                "org.jpos.groovy.JPOSGroovyDefaults." ]
+@CompileStatic
+private static boolean shouldExclude(String className)
+{
+  for (String f in filter)
+  {
+    if (className.startsWith(f))
+        return true
+  }
+  return false
+}
+
+
+/* Based on org.jpos.util.Caller.info(int) */
+@CompileStatic
+private static String info(int pos)
+{
+    StackTraceElement [] stels= Thread.currentThread().getStackTrace()
+    StackTraceElement st= stels[stels.length - 1]       // avoid jumping out of the stack
+
+    // Find the useful stack position,  when ignoring internal groovy and java reflection stuff
+    int wantedPos= pos + 3
+    pos= 0
+    for (StackTraceElement el : stels)
+    {
+        if (!shouldExclude(el.getClassName()))
+        {
+            if (pos++ == wantedPos)
+            {
+                st= el  // found it!
+                break
+            }
+        }
+    }
+
+    String clazz = st.getClassName()
+    StringBuilder sb = new StringBuilder(Caller.shortClassName(clazz))
+    return sb.append(".").append(st.getMethodName())
+            .append(':')
+            .append(Integer.toString(st.getLineNumber()))
+            .toString()
+}
+
+
+def callermc= Caller.metaClass
+
+callermc.static.info = { int p -> info(p) }
+callermc.static.info = {       -> info(0) }
 

--- a/modules/groovy/src/main/resources/org/jpos/groovy/JPOSGroovyDefaults.groovy
+++ b/modules/groovy/src/main/resources/org/jpos/groovy/JPOSGroovyDefaults.groovy
@@ -1,6 +1,6 @@
 /*
  * jPOS Project [http://jpos.org]
- * Copyright (C) 2000-2017 jPOS Software SRL
+ * Copyright (C) 2000-2020 jPOS Software SRL
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -16,10 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-// Groovy initialization to spice up Context object
+package org.jpos.groovy
 
 import org.jpos.transaction.*
+
+// Groovy initialization to spice up Context object
 
 
 def ctxmc= Context.metaClass
@@ -42,4 +43,3 @@ ctxmc.putAt= { Object key, Object val ->
 }
 
 
-return ctxmc


### PR DESCRIPTION
Now we can transparently call `org.jpos.util.Caller.info()` from Groovy code and the output will make sense, being equivalent to what one would expect in Java
It will output the correct groovy line number, and show the script name if it's an external Groovy class/file, or for embedded scripts in `GroovyParticipant` and `GroovyListener` it will show something like  `GroovyParticipant_prepare__myRealmName.run:32`