### PR TITLE
Remove useless max-random-operations feature from CryptoService

### DIFF
--- a/doc/src/asciidoc/module_cryptoservice.adoc
+++ b/doc/src/asciidoc/module_cryptoservice.adoc
@@ -65,9 +65,8 @@ The crypto service can be configured using a QBean descriptor like this:
     <property name="keylength" value="256" />                         <5>
     <property name="duration" value="86400000" />                     <6>
     <property name="ttl" value="3600000" />                           <7>
-    <property name="max-random-operations" value="1000000" />         <8>
     <ks-provider 
-    class="org.jpos.crypto.SysConfigCryptoServiceKeyStoreProvider" /> <9>
+    class="org.jpos.crypto.SysConfigCryptoServiceKeyStoreProvider" /> <8>
 </crypto-service>
 ------------
 <1> custodian PGP id, there can be many `custodian` entries.
@@ -77,8 +76,7 @@ The crypto service can be configured using a QBean descriptor like this:
 <5> key length defaults to 256. Can be reduced if AES-256 is not supported by the JVM due to export restrictions.
 <6> key duration
 <7> internal key cache time-to-live (in millis).
-<8> after max-random-operations (default to 100000), SecureRandom object gets discarded.
-<9> CryptoServiceKeyStoreProvider class configuration.
+<8> CryptoServiceKeyStoreProvider class configuration.
 
 [TIP]
 =====

--- a/modules/cryptoservice/src/main/java/org/jpos/crypto/CryptoService.java
+++ b/modules/cryptoservice/src/main/java/org/jpos/crypto/CryptoService.java
@@ -77,9 +77,12 @@ public final class CryptoService extends QBeanSupport implements Runnable, XmlCo
     private long ttl;
     private long duration;
     private Supplier<String> unlock;
-    private Recyclable<Random> rnd;
-    private int maxRandomOperations = 100000;
+    private static SecureRandom rnd;
     private CryptoServiceKeyStoreProvider ksProvider;
+
+    static {
+        rnd = new SecureRandom();
+    }
 
     /**
      * Encrypts data using the current key
@@ -201,7 +204,6 @@ public final class CryptoService extends QBeanSupport implements Runnable, XmlCo
 
     @Override
     protected void initService() throws ConfigurationException {
-        rnd = new Recyclable<>(SecureRandom::new, maxRandomOperations);
         if (!lazy.get())
             new Thread(this, getName()).start();
         NameRegistrar.register(getName(), this);
@@ -230,7 +232,6 @@ public final class CryptoService extends QBeanSupport implements Runnable, XmlCo
         waitTimeout = cfg.getLong("timeout", 30000L);
         ttl = cfg.getLong("ttl", 3600000L);
         duration = cfg.getLong("duration", 86400000L);
-        maxRandomOperations = cfg.getInt("max-random-operations", 100000);
         String unlockPassword = cfg.get("unlock-password", null);
         if (unlockPassword != null) {
             try {
@@ -302,7 +303,7 @@ public final class CryptoService extends QBeanSupport implements Runnable, XmlCo
 
     private byte[] randomIV() {
         final byte[] b = new byte[16];
-        rnd.get().nextBytes(b);
+        rnd.nextBytes(b);
         return b;
     }
 


### PR DESCRIPTION
It appears this feature was added based on incorrect information in #92.