### PR TITLE
Qi simplify validator handling in helpers and add unique validator

### DIFF
--- a/modules/qi-core/src/main/java/org/jpos/qi/QIEntityView.java
+++ b/modules/qi-core/src/main/java/org/jpos/qi/QIEntityView.java
@@ -521,7 +521,7 @@ public abstract class QIEntityView<T> extends VerticalLayout implements View, Co
     }
 
     public FieldFactory createFieldFactory () {
-        return new FieldFactory(getBean(), getViewConfig(), getBinder());
+        return new FieldFactory(getBean(), getViewConfig(), getBinder(), helper.getValidators());
     }
 
     protected void addFields (Layout leftLayout, Layout rightLayout, Layout formLayout) {

--- a/modules/qi-core/src/main/java/org/jpos/qi/QIHelper.java
+++ b/modules/qi-core/src/main/java/org/jpos/qi/QIHelper.java
@@ -19,6 +19,7 @@
 package org.jpos.qi;
 
 import com.vaadin.data.Binder;
+import com.vaadin.data.Validator;
 import com.vaadin.data.provider.CallbackDataProvider;
 import com.vaadin.data.provider.DataProvider;
 import com.vaadin.data.provider.QuerySortOrder;
@@ -39,6 +40,7 @@ public abstract class QIHelper {
     protected Class clazz;
     private Configuration cfg;
     private Object originalEntity;
+    private Map<String, List<Validator>> validators = new HashMap<>();
 
 
     protected QIHelper(Class clazz) {
@@ -266,5 +268,19 @@ public abstract class QIHelper {
 
     public void setOriginalEntity(Object originalEntity) {
         this.originalEntity = originalEntity;
+    }
+
+
+    public void addValidators(String key, Validator ... validators){
+        List<Validator> v = this.validators.computeIfAbsent(key, k -> new LinkedList<>());
+        for (Validator validator: validators) v.add(validator);
+    }
+
+    public List<Validator> getValidators(String key) {
+        return validators.getOrDefault(key, Collections.emptyList());
+    }
+
+    public Map<String, List<Validator>> getValidators() {
+        return validators;
     }
 }

--- a/modules/qi-core/src/main/java/org/jpos/qi/util/FieldFactory.java
+++ b/modules/qi-core/src/main/java/org/jpos/qi/util/FieldFactory.java
@@ -43,11 +43,17 @@ public class FieldFactory {
     private Object bean;
     private ViewConfig viewConfig;
     private Binder binder;
+    private Map<String, List<Validator>> validators;
 
     public FieldFactory(Object bean, ViewConfig viewConfig, Binder binder) {
         this.bean = bean;
         this.viewConfig = viewConfig;
         this.binder = binder;
+    }
+
+    public FieldFactory(Object bean, ViewConfig viewConfig, Binder binder, Map<String, List<Validator>> validators) {
+        this(bean, viewConfig, binder);
+        this.validators = validators;
     }
 
     public HasValue buildAndBindField (String id) throws NoSuchFieldException {
@@ -196,7 +202,7 @@ public class FieldFactory {
     //Override to add more customValidators
     public List<Validator> getValidators(String propertyId) {
         if (viewConfig == null)
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         List<Validator> validators = new ArrayList<>();
         ViewConfig.FieldConfig config = viewConfig.getFields().get(propertyId);
         if (config != null) {
@@ -215,6 +221,10 @@ public class FieldFactory {
                 });
             }
         }
+
+        if (this.validators != null)
+            validators.addAll(this.validators.getOrDefault(propertyId, Collections.emptyList()));
+
         return validators;
     }
 

--- a/modules/qi-core/src/main/java/org/jpos/qi/util/UniqueValidator.java
+++ b/modules/qi-core/src/main/java/org/jpos/qi/util/UniqueValidator.java
@@ -1,0 +1,76 @@
+package org.jpos.qi.util;
+
+import com.vaadin.data.ValidationResult;
+import com.vaadin.data.Validator;
+import com.vaadin.data.ValueContext;
+import org.jpos.ee.DB;
+import org.jpos.ee.DBManager;
+import org.jpos.qi.QIHelper;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+
+public class UniqueValidator<T, FieldType> implements Validator<FieldType> {
+    protected QIHelper helper;
+    Class<T> clazz;
+    Method idGetter;
+    Method fieldGetter;
+    String field;
+    String errorMessageCode;
+
+    public UniqueValidator(QIHelper helper, Class<T> clazz, String field)
+            throws IntrospectionException
+    {
+        this(helper, clazz, field, "errorMessage." + field + "AlreadyExists");
+    }
+
+    public UniqueValidator(QIHelper helper, Class<T> clazz, String field, String errorMessageCode)
+            throws IntrospectionException
+    {
+        this(helper, clazz, field, errorMessageCode, "id");
+    }
+
+    public UniqueValidator(QIHelper helper, Class<T> clazz, String field, String errorMessageCode, String idField)
+            throws IntrospectionException
+    {
+        this.helper = helper;
+        this.clazz = clazz;
+        this.field = field;
+        this.errorMessageCode = errorMessageCode;
+        for (PropertyDescriptor property : Introspector.getBeanInfo(clazz).getPropertyDescriptors()) {
+            if (property.getName().equals(field)) fieldGetter = property.getReadMethod();
+            else if (property.getName().equals(idField)) idGetter = property.getReadMethod();
+        }
+    }
+
+
+    /**
+     * Validates the given value. Returns a {@code ValidationResult} instance
+     * representing the outcome of the validation.
+     *
+     * @param value   the input value to validate
+     * @param context the value context for validation
+     * @return the validation result
+     */
+    @Override
+    public ValidationResult apply(FieldType value, ValueContext context) {
+        @SuppressWarnings("unchecked")
+        T originalEntity = (T) helper.getOriginalEntity();
+        try {
+            T found = DB.exec(db -> new DBManager<>(db, clazz).getItemByParam(field, value));
+            if (found == null ||
+                    originalEntity != null && idGetter.invoke(found).equals(idGetter.invoke(originalEntity)))
+            {
+                return ValidationResult.ok();
+            } else {
+                return ValidationResult.error(helper.getApp().getMessage(errorMessageCode, value));
+            }
+        } catch (Exception e) {
+            helper.getApp().getLog().error(e);
+            return ValidationResult.error(helper.getApp().getMessage(e.getClass().getName(), e.getMessage()));
+        }
+
+    }
+}


### PR DESCRIPTION
With this PR (which is backward compatible) we can add validators in helpers without the need to extend `FieldFactory`.

Also a generic unique validator for entities is added, this can be used to easly add validators that check uniqueness of given field.