### PR TITLE
Skip BinLogTest on OSX due to lock contention performance issues

### DIFF
--- a/modules/binlog/build.gradle
+++ b/modules/binlog/build.gradle
@@ -2,5 +2,6 @@ description = 'jPOS-EE :: BinLog Module'
 
 dependencies {
     api libraries.jpos
+    testImplementation libraries.commons_lang
 }
 

--- a/modules/binlog/src/test/java/org/jpos/binlog/BinLogTest.java
+++ b/modules/binlog/src/test/java/org/jpos/binlog/BinLogTest.java
@@ -34,6 +34,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC_OSX;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
@@ -44,7 +46,8 @@ public class BinLogTest implements Runnable {
 
     @BeforeEach
     public void before () {
-        Assumptions.assumeFalse(System.getProperty("os.name").startsWith("Windows")); //Skip Tests for BinLog if on MS Windows
+        // Skip Tests for BinLog if on MS Windows/OSX due to severe lock contention performance issues
+        Assumptions.assumeFalse(IS_OS_WINDOWS || IS_OS_MAC_OSX);
     }
     
     @BeforeAll


### PR DESCRIPTION
This test takes about 20 minutes to run on OSX due to OSX having very bad performance under high contention locking between multiple threads.