### PR TITLE
Skip BinLogTest on OSX for Java 9 and newer due to fcntl(fd, F_FULLSYNC) being slow.

### DIFF
--- a/modules/binlog/build.gradle
+++ b/modules/binlog/build.gradle
@@ -2,5 +2,6 @@ description = 'jPOS-EE :: BinLog Module'
 
 dependencies {
     api libraries.jpos
+    testImplementation libraries.commons_lang
 }
 

--- a/modules/binlog/src/test/java/org/jpos/binlog/BinLogTest.java
+++ b/modules/binlog/src/test/java/org/jpos/binlog/BinLogTest.java
@@ -34,6 +34,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_9;
+import static org.apache.commons.lang3.SystemUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
@@ -44,7 +46,12 @@ public class BinLogTest implements Runnable {
 
     @BeforeEach
     public void before () {
-        Assumptions.assumeFalse(System.getProperty("os.name").startsWith("Windows")); //Skip Tests for BinLog if on MS Windows
+        /**
+         * Skip Tests for BinLog if on MS Windows due to file locking considerations
+         * Skip Binlog Tests for OSX on Java 9 and newer due to fcntl(fd, F_FULLSYNC) being slow
+         * Note: Java 8 does not properly flush buffers to disk on OSX
+         */
+        Assumptions.assumeFalse(IS_OS_WINDOWS || (IS_OS_MAC_OSX && isJavaVersionAtLeast(JAVA_9)));
     }
     
     @BeforeAll


### PR DESCRIPTION
Note: Java 8 and older does not use fcntl(fd, F_FULLSYNC) and won't fully flush buffers to disk.

See: https://github.com/AdoptOpenJDK/openjdk-jdk9/commit/44491925c5130b1c62f40b80f331caa58c97b92c