### PR TITLE
Added versions of createReverse able to preserve tags of entries 

### DIFF
--- a/modules/minigl/src/main/java/org/jpos/gl/GLTransaction.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/GLTransaction.java
@@ -284,6 +284,7 @@ public class GLTransaction extends Cloneable {
     {
         return createGLEntry (acct, amount, detail, true, layer);
     }
+
     /**
      *
      * Create a reverse transaction based on this one
@@ -291,16 +292,28 @@ public class GLTransaction extends Cloneable {
      * @return a reversal transaction
      */
     public GLTransaction createReverse() {
+        return createReverse(false);
+    }
+
+    /**
+     *
+     * Create a reverse transaction based on this one
+     *
+     * @param keepEntryTags if true entries tags are copied to the reversal entries
+     * @return a reversal transaction
+     */
+    public GLTransaction createReverse(boolean keepEntryTags) {
         GLTransaction glt = new GLTransaction ("(" + getDetail() + ")");
         glt.setJournal (getJournal());
         for (GLEntry e : getEntries()) {
-            glt.createGLEntry(
+            GLEntry reversalEntry = glt.createGLEntry(
               e.getAccount(),
               negate(e.getAmount()),
               e.getDetail(),
               e.isCredit(),
               e.getLayer()
             );
+            if (keepEntryTags) reversalEntry.setTags(e.getTags());
         }
         return glt;
     }
@@ -315,6 +328,20 @@ public class GLTransaction extends Cloneable {
      * @return a reversal transaction
      */
     public GLTransaction createReverse(Tags withTags, Tags withoutTags) {
+        return createReverse(withTags, withoutTags, false);
+    }
+
+    /**
+     *
+     * Create a reverse transaction based on this one
+     *
+     * @param withTags entries with any tag in <code>withTags</code> are selected (can be null)
+     * @param withoutTags entries with any tag in <code>withoutTags</code> are discarded (can be null)
+     *
+     * @param keepEntryTags if true, reverse entries have the same tags as the original ones
+     * @return a reversal transaction
+     */
+    public GLTransaction createReverse(Tags withTags, Tags withoutTags, boolean keepEntryTags) {
         GLTransaction glt = new GLTransaction ("(" + getDetail() + ")");
         glt.setJournal (getJournal());
         for (GLEntry e : getEntries()) {
@@ -322,13 +349,14 @@ public class GLTransaction extends Cloneable {
             if ((withTags == null || tags.containsAll(withTags)) &&
               (withoutTags == null || !tags.containsAny(withoutTags)))
             {
-                glt.createGLEntry(
+                GLEntry reversalEntry = glt.createGLEntry(
                   e.getAccount(),
                   negate(e.getAmount()),
                   e.getDetail(),
                   e.isCredit(),
                   e.getLayer()
                 );
+                if (keepEntryTags) reversalEntry.setTags(e.getTags());
             }
         }
         return glt;
@@ -394,7 +422,7 @@ public class GLTransaction extends Cloneable {
             .toHashCode();
     }
     public boolean hasLayers (short[] layers) {
-        for (GLEntry e : (List<GLEntry>) getEntries()) {
+        for (GLEntry e : getEntries()) {
             if (e.hasLayers (layers))
                 return true;
         }
@@ -418,7 +446,7 @@ public class GLTransaction extends Cloneable {
         }
         return credits;
     }
-    @SuppressWarnings("unchecked")
+
     public BigDecimal getImpact(Account acct, short[] layers) {
         BigDecimal impact = GLSession.ZERO;
         for (GLEntry e : getEntries()) {

--- a/modules/minigl/src/test/java/org/jpos/gl/GLTransactionTest.java
+++ b/modules/minigl/src/test/java/org/jpos/gl/GLTransactionTest.java
@@ -1,0 +1,89 @@
+package org.jpos.gl;
+
+import org.jpos.util.Tags;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+class GLTransactionTest extends TestBase{
+
+    FinalAccount bobEquity, aliceEquity;
+    GLTransaction transactionForReverse;
+    static final String CREDIT_TAG = "credit";
+    static final String DEBIT_TAG = "debit";
+    static final String TEST_TAG = "test";
+    static final short LAYER = 2;
+    static final short[] LAYERS = {LAYER};
+
+    static final BigDecimal AMOUNT = new BigDecimal(1000).setScale(2);
+
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        bobEquity = (FinalAccount) gls.getAccount ("TestChart", "31");
+        aliceEquity = (FinalAccount) gls.getAccount ("TestChart", "32");
+        transactionForReverse = new GLTransaction ("Single-post in layer two");
+        transactionForReverse.setPostDate (new Date());
+        GLEntry debit = transactionForReverse.createDebit (
+                bobEquity,
+                AMOUNT,
+                null, (short) 2
+        );
+        debit.setTags(new Tags(DEBIT_TAG, TEST_TAG));
+        GLEntry credit = transactionForReverse.createCredit (
+                aliceEquity,
+                AMOUNT,
+                null, (short) 2
+        );
+
+        credit.setTags(new Tags(CREDIT_TAG, TEST_TAG));
+    }
+
+    @Test
+    void testCreateReverse() {
+        GLTransaction reversal = transactionForReverse. createReverse();
+        Assertions.assertEquals(reversal.getImpact(bobEquity, LAYERS), transactionForReverse.getImpact(bobEquity, LAYERS).negate(), "reverse impact is not the opposite");
+        Assertions.assertEquals(reversal.getImpact(aliceEquity, LAYERS), transactionForReverse.getImpact(aliceEquity, LAYERS).negate(), "reverse impact is not the opposite");
+        Assertions.assertEquals(reversal.getEntries().size(), 2);
+        for (GLEntry entry : reversal.getEntries()) {
+            Assertions.assertNull(entry.getTags());
+        }
+    }
+
+    @Test
+    void testCreateReverseKeepTags() {
+        GLTransaction reversal = transactionForReverse. createReverse(true);
+        Assertions.assertEquals(reversal.getImpact(bobEquity, LAYERS), transactionForReverse.getImpact(bobEquity, LAYERS).negate(), "reverse impact is not the opposite");
+        Assertions.assertEquals(reversal.getImpact(aliceEquity, LAYERS), transactionForReverse.getImpact(aliceEquity, LAYERS).negate(), "reverse impact is not the opposite");
+        Assertions.assertEquals(reversal.getEntries().size(), 2);
+        for (GLEntry entry : reversal.getEntries()) {
+            Assertions.assertTrue(entry.getTags().contains(TEST_TAG));
+        }
+    }
+
+    @Test
+    void testCreateReverseWithTags() {
+        GLTransaction reversal = transactionForReverse. createReverse(new Tags(TEST_TAG), new Tags(DEBIT_TAG));
+        Assertions.assertEquals(reversal.getImpact(aliceEquity, LAYERS), transactionForReverse.getImpact(aliceEquity, LAYERS).negate(), "reverse impact is not the opposite");
+        Assertions.assertEquals(0, reversal.getImpact(bobEquity, LAYERS).compareTo(BigDecimal.ZERO), "reverse impact is not the opposite");
+        Assertions.assertEquals(reversal.getEntries().size(), 1);
+        for (GLEntry entry : reversal.getEntries()) {
+            Assertions.assertNull(entry.getTags());
+        }
+    }
+
+    @Test
+    void testCreateReverseWithTagsKeepTags() {
+        GLTransaction reversal = transactionForReverse. createReverse(new Tags(TEST_TAG), new Tags(DEBIT_TAG),true);
+        Assertions.assertEquals(reversal.getImpact(aliceEquity, LAYERS), transactionForReverse.getImpact(aliceEquity, LAYERS).negate(), "reverse impact is not the opposite");
+        Assertions.assertEquals(0, reversal.getImpact(bobEquity, LAYERS).compareTo(BigDecimal.ZERO), "reverse impact is not the opposite");
+        Assertions.assertEquals(reversal.getEntries().size(), 1);
+        for (GLEntry entry : reversal.getEntries()) {
+            Assertions.assertEquals(entry.getTags(), new Tags(TEST_TAG, CREDIT_TAG));
+        }
+    }
+}

--- a/modules/minigl/src/test/java/org/jpos/gl/TestBase.java
+++ b/modules/minigl/src/test/java/org/jpos/gl/TestBase.java
@@ -34,8 +34,8 @@ public abstract class TestBase {
             String userName = System.getProperty("user.name");
             System.setProperty("user.name", "travis");
             new Import().parse("../test-classes/testdata.xml");
-            System.setProperty("user.name", userName);
             new Export().export(System.out);
+            System.setProperty("user.name", userName);
         } catch (Exception e) {
             e.printStackTrace();
             throw e;


### PR DESCRIPTION
closes #158 Create versions of `GLTransaction.createReverse(...)`  that preserve tags for created reversal entries

Also:
- cleaned up some unnecessary code
- fixed minigl TestBase: Export needs test user, this wasn't giving trouble from gradle but yes when run as a standalone test, thing is export also needs valid  user with read permissions.
