### PR TITLE
BalanceTest: createCheckpoint must be enclosed in beginTransaction/comit

### DIFF
--- a/modules/minigl/src/test/java/org/jpos/gl/BalanceTest.java
+++ b/modules/minigl/src/test/java/org/jpos/gl/BalanceTest.java
@@ -64,9 +64,11 @@ public class BalanceTest extends TestBase {
     @Test
     @Order(3)
     public void testCheckpoints() throws Exception {
+        final Transaction tx1 = gls.beginTransaction();
         gls.createCheckpoint (tj, root, Util.parseDate ("20041231"), 1);
         gls.createCheckpoint (tj, root, Util.parseDate ("20050101"), 1);
         gls.createCheckpoint (tj, root, Util.parseDate ("20050102"), 1);
+        tx1.commit();
     }
     @Test
     @Order(4)

--- a/modules/minigl/src/test/java/org/jpos/gl/BalanceTest.java
+++ b/modules/minigl/src/test/java/org/jpos/gl/BalanceTest.java
@@ -280,6 +280,11 @@ public class BalanceTest extends TestBase {
             new BigDecimal("15000.00"),
             gls.getBalance (tj, cashUS, Util.parseDate ("20050101"))
         );
+        short[] zeroOnly = {0};
+        assertEquals (
+                new BigDecimal("25000.00"),
+                gls.getBalancesORM (tj, cashUS, Util.parseDate ("20050102"), true, zeroOnly, 0)[0]
+        );
         assertEquals (
             new BigDecimal("25000.00"),
             gls.getBalance (tj, cashUS, Util.parseDate ("20050102"))


### PR DESCRIPTION
This PR should trigger a test failure if my assessment is correct, which indicates there's a bug in getBalancesORM that people only get if they're _not_ using mysql or postgresql. Both commits are important for seperate reasons. 

- In BalanceTest.testCheckpoints, there is no transaction for the createCheckpoint calls, so before this PR, they weren't written to the database. The first commit fixes this.
 - The jpos tests use the H2 engine in memory for a test database. Because of this, getBalances uses getBalancesORM to load balances
 - When the checkpoints are present inserted, there is a disagreement between the output of getBalancesORM and getBalances. I've tested this by switching to postgresql - where getBalances doesn't use getBalancesORM, and this now returns the right result. So the improper calculation is due to the presence of checkpoints which are only used in getBalancesORM. The second commit highlights this, because even if you use postgres or H2, directly calling getBalancesORM will show you there's a bug.

My best guess at this time is that there's an off-by-one type edge case in getBalancesORM, when checkpoints are present. I believe it's due to the date which transactions are posted at. The transentry that highlights the issue is Bob Check #002 on 20050102. I believe when the checkpoint is made, there is a < when it should be <=.. or in getBalancesORM and a checkpoint is loaded, we need to use an >= operator instead of >

What's interesting is, if you change the date on the third checkpoint to 20050103, or any date after the third transaction, the balance is correctly reported as 25000! So I'm pretty sure it's down to the SELECT queries and the relational operators used there. 
I'm unsure whether the checkpoint should be 25000 or 15000.. so I'm not 100% confident I could fix this without breaking other applications. but I wanted to open this PR to highlight the issue and see what the expected behavior should be. Trying to work through it though :)