### PR TITLE
Add strict account checks by default

### DIFF
--- a/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
@@ -50,6 +50,7 @@ public class GLSession {
     public static final BigDecimal Z    = new BigDecimal ("0");
     private long SAFE_WINDOW = 1000L;
     private boolean ignoreBalanceCache = false;
+    private boolean strictAccountCodes = true;
     private NativeDialect nativeDialect = NativeDialect.ORM;
 
     private static String POSTGRESQL_GET_BALANCES =
@@ -322,6 +323,7 @@ public class GLSession {
     {
         addAccount (parent, acct, true);
     }
+
     /**
      * Add account to parent.
      * Check permissions, parent's type and optional currency.
@@ -337,6 +339,9 @@ public class GLSession {
         throws HibernateException, GLException
     {
         checkPermission (GLPermission.WRITE);
+        if (strictAccountCodes)
+            validateAccountCode(parent, acct);
+
         if (!parent.isChart() && !parent.equalsType (acct)) {
             StringBuffer sb = new StringBuffer ("Type mismatch ");
             sb.append (parent.getTypeAsString());
@@ -1099,6 +1104,34 @@ public class GLSession {
         return balance;
     }
 
+    /**
+     * Get Both Balances at given date.
+     *
+     * IMPORTANT NOTE: This function uses different implementations depending on the
+     * dialect of the SQL server in use.  By default, native queries are generated for
+     * the MySQL and PostgreSQL dialect, with other dialects using getBalancesORM instead.
+     *
+     * Regarding balances of composite accounts - getBalancesORM knows that a given account
+     * is a child of a given parent correctly using the acct.parent reference, whereas the
+     * native queries in getBalances cut some corners in order to take advantage of the
+     * database index, it assumes that the parent shares the acct.code prefix.
+     *
+     * In such cases, if MySQL or PostgreSQL native queries are used for balance calculations,
+     * accounts not following this convention are excluded from the results resulting in the
+     * wrong balance.  This was the reason for adding stricter checks of account codes to
+     * Import.createCharts and GLSession.addAccount.
+     *
+     * It's possible to force the use of getBalancesORM by calling `GLSession.forceDialect`
+     *
+     * @param journal the journal.
+     * @param acct the account.
+     * @param date date (inclusive).
+     * @param inclusive either true or false
+     * @param layers the layers
+     * @param maxId maximum GLEntry ID to be considered in the query (if greater than zero)
+     * @return array of 2 BigDecimals with balance and entry count.
+     * @throws GLException if user doesn't have READ permission on this journal.
+     */
     public BigDecimal[] getBalances
       (Journal journal, Account acct, Date date, boolean inclusive, short[] layers, long maxId)
       throws HibernateException, GLException
@@ -1602,6 +1635,12 @@ public class GLSession {
         this.ignoreBalanceCache = ignoreBalanceCache;
     }
 
+    public boolean isEnforcingStrictAccountCodes() { return strictAccountCodes; }
+
+    public void setEnforceStrictAccountCodes(boolean strictAccountCodes) {
+        this.strictAccountCodes = strictAccountCodes;
+    }
+
     // -----------------------------------------------------------------------
     // PUBLIC HELPERS
     // -----------------------------------------------------------------------
@@ -1941,6 +1980,14 @@ public class GLSession {
             list.add((FinalAccount) acct);
         }
         return list;
+    }
+
+    private void validateAccountCode(Account parent, Account child)
+            throws GLException
+    {
+        if (!parent.isChart() && !child.getCode().startsWith(parent.getCode())) {
+            throw new GLException("Child account code `"+child.getCode()+"`must start with parent account code `"+parent.getCode()+"`");
+        }
     }
 
     public String toString() {

--- a/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
@@ -1986,7 +1986,7 @@ public class GLSession {
             throws GLException
     {
         if (!parent.isChart() && !child.getCode().startsWith(parent.getCode())) {
-            throw new GLException("Child account code `"+child.getCode()+"`must start with parent account code `"+parent.getCode()+"`");
+            throw new GLException("Child account code `"+child.getCode()+"` must start with parent account code `"+parent.getCode()+"`");
         }
     }
 

--- a/modules/minigl/src/main/java/org/jpos/gl/tools/Import.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/tools/Import.java
@@ -177,7 +177,7 @@ public class Import implements EntityResolver {
             throws GLException
     {
         if (!parent.isChart() && !child.getCode().startsWith(parent.getCode())) {
-            throw new GLException("Child account code `"+child.getCode()+"`must start with parent account code `"+parent.getCode()+"`");
+            throw new GLException("Child account code `"+child.getCode()+"` must start with parent account code `"+parent.getCode()+"`");
         }
     }
     private void createComposite (Session sess, CompositeAccount parent, Element elem) 

--- a/modules/minigl/src/main/java/org/jpos/gl/tools/Import.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/tools/Import.java
@@ -60,7 +60,7 @@ public class Import implements EntityResolver {
      * but may be set to false to import a legacy system that doesn't
      * use native queries.
      */
-    private Boolean strictAccountCodes = true;
+    private boolean strictAccountCodes = true;
 
     public Import () throws HibernateException, GLException, IOException, ConfigurationException
     {

--- a/modules/minigl/src/test/java/org/jpos/gl/AccountTest.java
+++ b/modules/minigl/src/test/java/org/jpos/gl/AccountTest.java
@@ -1,0 +1,79 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2020 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.gl;
+
+import org.hibernate.Transaction;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AccountTest extends TestBase {
+    private Account createNonCanonicalAccount(CompositeAccount parent) {
+        Account newac = new FinalAccount();
+        newac.setParent(parent);
+        newac.setType(Account.DEBIT);
+        newac.setCode("invalid");
+        return newac;
+    }
+
+    @Test
+    public void errorThrownIfStrictChecksFail () throws Exception {
+        CompositeAccount parent = gls.getCompositeAccount("TestChart", "11");
+        assertFalse(parent.isChart());
+        assertTrue(gls.isEnforcingStrictAccountCodes());
+        Transaction tx = gls.beginTransaction();
+        try {
+            Account newac = createNonCanonicalAccount(parent);
+            gls.addAccount(parent, newac);
+            tx.commit();
+        } catch (GLException e) {
+            tx.rollback();
+            if (!e.getMessage().equals (
+                    "Child account code `invalid` must start with parent account code `11`"))
+            {
+                fail ("Unexpected GLException " + e.getMessage());
+            }
+            return;
+        }
+        fail ("GLException should have been raised");
+    }
+
+    @Test
+    public void noErrorIfStrictChecksDisabled () throws Exception {
+        assertTrue(gls.isEnforcingStrictAccountCodes());
+        gls.setEnforceStrictAccountCodes(false);
+        assertFalse(gls.isEnforcingStrictAccountCodes());
+        try {
+            CompositeAccount parent = gls.getCompositeAccount("TestChart", "11");
+
+            Transaction tx = gls.beginTransaction();
+            try {
+                Account newac = createNonCanonicalAccount(parent);
+                gls.addAccount(parent, newac);
+                tx.commit();
+            } catch (Exception e) {
+                tx.rollback();
+                throw e;
+            }
+        } finally {
+            gls.setEnforceStrictAccountCodes(true);
+            assertTrue(gls.isEnforcingStrictAccountCodes());
+        }
+    }
+}


### PR DESCRIPTION
As discussed in #173, this PR adds a check in `GLSession.addAccount` and `Import.createCharts` that child accounts have the parent code as a prefix. In both cases, I added a function `setEnforceStrictAccountCodes` to both of these classes to enable people to disable the strict checks in legacy cases, or cases where people have non-canonical account names but don't use mysql or postgresql

I also added a description of the behavior in getBalances to explain the reason for the new check, how to disable it, and why it's there.

I added a test covering the new code in GLSession, but haven't added one for Import. Let me know if this would be best.

Fixes #173