### PR TITLE
Run tests in parallel.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ subprojects {
     }
     test {
         useJUnitPlatform()
+        maxParallelForks = Runtime.runtime.availableProcessors()
     }
     task sourceJar(type: Jar) {
         from sourceSets.main.allSource


### PR DESCRIPTION
This seems to have a much smaller impact than [#338](https://github.com/jpos/jPOS/pull/338) but is still slightly faster still from the looks of it.

Times for clean build+tests on my 16 core 32 thread Linux box.

Without this change:
```
BUILD SUCCESSFUL in 32s
```

With this change:
```
BUILD SUCCESSFUL in 27s
```