### PR TITLE
getBalances (native); only use balance cache when date is null

### DIFF
--- a/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
@@ -1153,7 +1153,7 @@ public class GLSession {
         BalanceCache bcache = null;
         select.append(", transacc as txn\n");
 
-        if (!ignoreBalanceCache) {
+        if (date == null && !ignoreBalanceCache) {
             short[] layersCopy = Arrays.copyOf(layers,layers.length);
             bcache = getBalanceCache(journal, acct, layersCopy);
             if (maxId > 0 && bcache != null && bcache.getRef() > maxId)


### PR DESCRIPTION
Fixes error introduced by myself in https://github.com/jpos/jPOS-EE/pull/177

The balance cache should only be used if date == null. Since the date != null condition is no longer tested, we ensure date == null before doing anything with the balance cache