### PR TITLE
HttpQuery: add preemptiveAuth cfg parameter for Preemptive Basic Authentication

### DIFF
--- a/doc/src/asciidoc/module_http_client.adoc
+++ b/doc/src/asciidoc/module_http_client.adoc
@@ -32,6 +32,7 @@ The `HttpQuery` participant has the following configuration properties:
 * `redirect-strategy`: Sets the strategy to use when the remote HTTP server returns a redirect.
    If the property is undefined, or has the "default" value, it will use Apache's `DefaultRedirectStrategy`.
    If the value is `lax` it will use `LaxRedirectStrategy` (see: https://hc.apache.org/httpcomponents-client-ga/tutorial/html/fundamentals.html)
+* `preemptiveAuth`: if doing Basic Authentication (by presence of context value), do it on the first request (default `false`)
 * `responseBodyOnError`: should an HTTP response body be included for responses with error
    status code? (`boolean`, default `false`);
 

--- a/doc/src/asciidoc/module_http_client.adoc
+++ b/doc/src/asciidoc/module_http_client.adoc
@@ -79,7 +79,7 @@ The default names used above can be overriden, e.g.:
     <property name="headersName" value="MY_HTTP_HEADERS" />
     <property name="contentTypeName" value="MY_HTTP_CONTENT_TYPE" />  <1>
     <property name="contentType" value="application/json" />          <2>
-    <property name="basicAuthenticationdName" value=".MY_BASIC_CREDENTIALS" /> <3>
+    <property name="basicAuthenticationName" value=".MY_BASIC_CREDENTIALS" /> <3>
   </participant>
 ------------
 <1> Name of the Context variable where user can override the default content type.

--- a/modules/http-client/src/main/java/org/jpos/http/client/HttpQuery.java
+++ b/modules/http-client/src/main/java/org/jpos/http/client/HttpQuery.java
@@ -181,7 +181,7 @@ public class HttpQuery extends Log implements AbortParticipant, Configurable, De
         responseName = cfg.get("responseName", "HTTP_RESPONSE");
         statusName = cfg.get("responseStatusName", "HTTP_STATUS");
 
-        basicAuthenticationName  = cfg.get("basicAuthenticationdName", ".HTTP_BASIC_AUTHENTICATION");
+        basicAuthenticationName = cfg.get("basicAuthenticationName", ".HTTP_BASIC_AUTHENTICATION");
 
         // ctx name under which extra http headers could exist at runtime
         // the object could be a List<String> or String[] (in the "name:value" format)

--- a/modules/http-client/src/main/java/org/jpos/http/client/HttpQuery.java
+++ b/modules/http-client/src/main/java/org/jpos/http/client/HttpQuery.java
@@ -20,11 +20,13 @@ package org.jpos.http.client;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.*;
 
 import org.apache.http.*;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.RedirectStrategy;
 import org.apache.http.client.config.RequestConfig;
@@ -34,6 +36,8 @@ import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.LaxRedirectStrategy;
@@ -62,6 +66,7 @@ public class HttpQuery extends Log implements AbortParticipant, Configurable, De
     private String contentType;
     private Header[] httpHeaders;
     private boolean responseOnError;
+    private boolean preemptiveAuth= false;          // Preemptive Basic Authentication (send on first request, false by default)
     private int connectTimeout;                     // timeout waiting for connection
     private int timeout;                            // timeout waiting for HTTP response on socket
 
@@ -115,6 +120,12 @@ public class HttpQuery extends Log implements AbortParticipant, Configurable, De
             // the credentials.
             // For preemptive authentication, an AuthCache needs to be configured.
             // Ref: https://hc.apache.org/httpcomponents-client-4.5.x/tutorial/html/authentication.html
+            if (preemptiveAuth) {
+                URI uri= httpRequest.getURI();
+                AuthCache authCache= new BasicAuthCache();
+                authCache.put(new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme()), new BasicScheme());
+                httpCtx.setAuthCache(authCache);
+            }
         }
 
         getHttpClient().execute(httpRequest, httpCtx, new FutureCallback<HttpResponse>() {
@@ -181,6 +192,7 @@ public class HttpQuery extends Log implements AbortParticipant, Configurable, De
         responseName = cfg.get("responseName", "HTTP_RESPONSE");
         statusName = cfg.get("responseStatusName", "HTTP_STATUS");
 
+        preemptiveAuth = cfg.getBoolean("preemptiveAuth", preemptiveAuth);
         basicAuthenticationName = cfg.get("basicAuthenticationName", ".HTTP_BASIC_AUTHENTICATION");
 
         // ctx name under which extra http headers could exist at runtime


### PR DESCRIPTION
and a typo fix for `basicAuthenticationName`