### PR TITLE
Removed redundant getBalance call

### DIFF
--- a/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
@@ -1445,8 +1445,7 @@ public class GLSession {
         (Journal journal, Account acct, short[] layers)
         throws HibernateException, GLException
     {
-        createBalanceCache (journal, acct, layers, getSafeMaxGLEntryId());
-        return getBalance  (journal, acct, layers);
+        return createBalanceCache (journal, acct, layers, getSafeMaxGLEntryId());
     }
     private BigDecimal createBalanceCache
         (Journal journal, Account acct, short[] layers, long maxId)


### PR DESCRIPTION
This PR is to further optimize the miniGL performance. Redundant queries erodes the performance when increasing number of transactions processed. 