### PR TITLE
Sort out compatibility issues with Microsoft SQL Server regarding max field lengths.

### DIFF
--- a/modules/eeuser/src/main/java/org/jpos/ee/Realm.java
+++ b/modules/eeuser/src/main/java/org/jpos/ee/Realm.java
@@ -37,7 +37,7 @@ public class Realm implements Serializable {
     @Column(length=64)
     private String name;
 
-    @Column(length=8192)
+    @Column(length=8000)
     private String description;
 
     public Long getId() {

--- a/modules/sysconfig/src/main/java/org/jpos/ee/SysConfig.java
+++ b/modules/sysconfig/src/main/java/org/jpos/ee/SysConfig.java
@@ -36,7 +36,7 @@ public class SysConfig extends Cloneable implements Serializable {
     @Column(length=64)
     private String id;
 
-    @Column(length=8192)
+    @Column(length=8000)
     private String value;
 
     @Column(length=64)


### PR DESCRIPTION
The length of `sysconfig.value` and `realm.description` have been changed down to 8000 since that's the max length that a SQL Server VARCHAR field can have.

For further information, please see https://www.sqlshack.com/sql-varchar-data-type-deep-dive/#:~:text=Also%20known%20as%20Variable%20Character,string%20using%20varchar%20data%20type. 