### PR TITLE
testdata.xml: change journal end date so it's still currently writable

### DIFF
--- a/modules/minigl/src/test/resources/testdata.xml
+++ b/modules/minigl/src/test/resources/testdata.xml
@@ -114,7 +114,8 @@
  <journal>
   <name>TestJournal</name>
   <start>20010101</start>
-  <end>20201231</end>
+  <!-- Increase by 10 years in 2030, and increment this number: 2 -->
+  <end>20301231</end>
   <status>open</status>
   <chart>TestChart</chart>
   <grant user="bob">post</grant>
@@ -153,7 +154,8 @@
  <journal>
   <name>HistoryJournal</name>
   <start>20010101</start>
-  <end>20201231</end>
+  <!-- Increase by 10 years in 2030, and increment this number: 2 -->
+  <end>20301231</end>
   <status>open</status>
   <chart>TestChart</chart>
   <grant user="bob">post</grant>


### PR DESCRIPTION
In testdata.xml, there are some sample journals. They specify an end date which, at the time of writing, is in the past and causes tests to fail, so I figured we can bump the date and move on.

I added a counter so people can track how many times this happens as once every 10 years is a small club :P Let me know if it's in poor taste and I can remove it. (or just bump to 2070 or something)