### PR TITLE
Jetty: externalize keystore password configuration.

### DIFF
--- a/modules/jetty/src/main/resources/META-INF/q2/installs/cfg/jetty.xml
+++ b/modules/jetty/src/main/resources/META-INF/q2/installs/cfg/jetty.xml
@@ -124,7 +124,6 @@
 
     <New id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
         <Set name="KeyStorePath"><Property name="jetty.home" default="." />/cfg/keystore.jks</Set>
-        <Set name="KeyStorePassword">jposjposjposjpos</Set>
         <Set name="ExcludeCipherSuites">
             <Array type="java.lang.String">
                 <Item>SSL_DHE_RSA_WITH_DES_CBC_SHA</Item>
@@ -309,4 +308,3 @@
       </Arg>
     </Call>
 </Configure>
-

--- a/modules/jetty/src/main/resources/META-INF/q2/installs/deploy/90_jetty.xml
+++ b/modules/jetty/src/main/resources/META-INF/q2/installs/deploy/90_jetty.xml
@@ -18,5 +18,11 @@
 
 <jetty class="org.jpos.q2.jetty.Jetty">
   <attr name="config">cfg/jetty.xml</attr>
+  <!-- 
+    For production systems, replace the literal value with a reference 
+    to a system or environment property.
+    For further information on the jPOS configuration sub-system, 
+    see jPOS Programmer's Guide, section 3.3. 
+  -->
+  <property name="keystorePassword" value="jposjposjposjpos"/>
 </jetty>
-


### PR DESCRIPTION
This PR adds a new option to set the keystore password for Jetty through the QBean configuration, thus leveraging jPOS' configuration sub-system.