### PR TITLE
fix(Issue #208): Jpos hangs on htp response 204 no content

### DIFF
--- a/modules/http-client/src/main/java/org/jpos/http/client/HttpQuery.java
+++ b/modules/http-client/src/main/java/org/jpos/http/client/HttpQuery.java
@@ -162,10 +162,8 @@ public class HttpQuery extends Log implements AbortParticipant, Configurable, De
                 boolean includeResponse= (sc == HttpStatus.SC_CREATED) || (sc == HttpStatus.SC_OK) || responseOnError;
                 if (includeResponse) {
                     try {
-                        if (result.getEntity() != null) {
+                        if (null != result.getEntity()) {
                             ctx.put(responseName, EntityUtils.toString(result.getEntity()));
-                        } else {
-                            ctx.put("HTTP_RESPONSE_STATUS", sc);
                         }
                     } catch (IOException e) {
                         ctx.log (e);

--- a/modules/http-client/src/main/java/org/jpos/http/client/HttpQuery.java
+++ b/modules/http-client/src/main/java/org/jpos/http/client/HttpQuery.java
@@ -162,7 +162,11 @@ public class HttpQuery extends Log implements AbortParticipant, Configurable, De
                 boolean includeResponse= (sc == HttpStatus.SC_CREATED) || (sc == HttpStatus.SC_OK) || responseOnError;
                 if (includeResponse) {
                     try {
-                        ctx.put (responseName, EntityUtils.toString(result.getEntity()));
+                        if (result.getEntity() != null) {
+                            ctx.put(responseName, EntityUtils.toString(result.getEntity()));
+                        } else {
+                            ctx.put("HTTP_RESPONSE_STATUS", sc);
+                        }
                     } catch (IOException e) {
                         ctx.log (e);
                     }


### PR DESCRIPTION
Jpos hangs when a server response is 204 no content. in the case where
the responseBodyOnError is set true and the response status is 204 jpos
hangs becuase there is no response body to process. This causes the
EntityUtils to attempt to process the response, calling the
result.getEntity() which does nothing. This change allows for the
situation where 204 is the response staus, and the responseBodyOnError
to be true but not call the EntityUtils when there is no response body
to process, by adding the status to the context using the mapping value
of HTTP_RESPONSE_STATUS