### PR TITLE
Let Heartbeat update status properties if exists.

### DIFF
--- a/modules/status/src/main/java/org/jpos/ee/status/Heartbeat.java
+++ b/modules/status/src/main/java/org/jpos/ee/status/Heartbeat.java
@@ -69,7 +69,7 @@ public class Heartbeat extends QBeanSupport implements Runnable {
     }
     protected String getDetail (long start, int tick) {
         Runtime r = Runtime.getRuntime();
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append ("memory=");
         sb.append (r.totalMemory());
         sb.append (", threads=");
@@ -87,9 +87,9 @@ public class Heartbeat extends QBeanSupport implements Runnable {
             db.open ();
             statusId = cfg.get ("status-id", getName());
             Status s = mgr.getStatus (statusId, false);
-            if (s == null) {
+            if (s == null || cfg.getBoolean("update-status")) {
                 Transaction tx = db.beginTransaction();
-                s = mgr.getStatus (statusId, true);
+                if (s== null) s = mgr.getStatus (statusId, true);
                 s.setName (cfg.get ("status-name", statusId));
                 s.setGroupName (cfg.get ("status-group", ""));
                 s.setTimeoutState (cfg.get ("on-timeout", Status.OFF));


### PR DESCRIPTION
When the status of `Heartbeat` already exists, the property `update-status` says if the qbean should update its properties on init.

For backward compatibility `update-status` is considered false by default, but maybe the expected default behaviour is to update the value, because when you change a property like the group or timeout you expect it to be reflected in the status.