### PR TITLE
GLTransaction simplify method

### DIFF
--- a/modules/minigl/src/main/java/org/jpos/gl/GLTransaction.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/GLTransaction.java
@@ -399,13 +399,12 @@ public class GLTransaction extends Cloneable {
     public GLTransaction simplify() {
         GLTransaction glt = new GLTransaction(getDetail());
         for (GLEntry e : getEntries()) {
-            if (e.getAmount() != BigDecimal.ZERO) {
+            if (e.getAmount() != BigDecimal.ZERO ) {
                 GLEntry redundantEntry = getEntries().stream().filter(entry ->
                 entry.getAccount().equals(e.getAccount()) &&
-                entry.getAmount() == e.getAmount() &&
+                entry.getAmount().compareTo(e.getAmount()) == 0 &&
                 entry.getLayer() == e.getLayer() &&
-                e.isCredit() ? !entry.isCredit() : entry.isCredit())
-                .findAny().orElse(null);
+                (e.isCredit() && !entry.isCredit() || !e.isCredit() && entry.isCredit())).findAny().orElse(null);
                 if (redundantEntry == null) {
                     glt.createGLEntry(e.getAccount(), e.getAmount(), e.getDetail(), e.isCredit(), e.getLayer());
                     glt.setTags(e.getTags());

--- a/modules/minigl/src/main/java/org/jpos/gl/GLTransaction.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/GLTransaction.java
@@ -20,6 +20,7 @@ package org.jpos.gl;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.ArrayList;
 import java.math.BigDecimal;
 import java.text.ParseException;
@@ -386,6 +387,29 @@ public class GLTransaction extends Cloneable {
                   e.getLayer()
                 );
                 if (keepEntryTags) reversalEntry.setTags(e.getTags());
+            }
+        }
+        return glt;
+    }
+
+    /**
+     * Create a simplified transaction based on this one
+     */
+
+    public GLTransaction simplify() {
+        GLTransaction glt = new GLTransaction(getDetail());
+        for (GLEntry e : getEntries()) {
+            if (e.getAmount() != BigDecimal.ZERO) {
+                GLEntry redundantEntry = getEntries().stream().filter(entry ->
+                entry.getAccount().equals(e.getAccount()) &&
+                entry.getAmount() == e.getAmount() &&
+                entry.getLayer() == e.getLayer() &&
+                e.isCredit() ? !entry.isCredit() : entry.isCredit())
+                .findAny().orElse(null);
+                if (redundantEntry == null) {
+                    glt.createGLEntry(e.getAccount(), e.getAmount(), e.getDetail(), e.isCredit(), e.getLayer());
+                    glt.setTags(e.getTags());
+                }
             }
         }
         return glt;


### PR DESCRIPTION
Adds a new method in GLTransaction to simplify a transaction, by removing redundant entries. 

Redundant entries are those which have amount 0, or have an opposite entry in the same GLTransaction with the same account, same layer, and same amount. 