### PR TITLE
Disable DB.createSchema by default

### DIFF
--- a/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
@@ -286,8 +286,12 @@ public class DB implements Closeable {
                     targetTypes.add(TargetType.SCRIPT);
                 }
             }
-            if (create)
-                targetTypes.add(TargetType.DATABASE);
+            if (create) {
+                if (isCreateEnabled())
+                    targetTypes.add(TargetType.DATABASE);
+                else
+                    throw new IllegalStateException ("createSchema not enabled");
+            }
             if(targetTypes.size()>0) {
                 // First, drop everything, disregarding errors
                 export.setHaltOnError(false);
@@ -302,6 +306,11 @@ public class DB implements Closeable {
             throw new HibernateException("Could not create schema", e);
         }
     }
+
+    private boolean isCreateEnabled() {
+        return "YES".equals(System.getProperty("db.create.enabled"));
+    }
+
 
     /**
      * open a new HibernateSession if none exists

--- a/modules/eeuser/src/test/java/org/jpos/ee/EEUserTest.java
+++ b/modules/eeuser/src/test/java/org/jpos/ee/EEUserTest.java
@@ -30,9 +30,11 @@ public class EEUserTest {
     DB db;
     @BeforeEach
     public void setUp() throws Exception {
+        System.setProperty("db.create.enabled", "YES");
         db = new DB();
         db.createSchema("schema.sql", true);
         db.open();
+        System.setProperty("db.create.enabled", "FALSE");
     }
 
     @Test

--- a/modules/minigl/src/test/java/org/jpos/gl/TestBase.java
+++ b/modules/minigl/src/test/java/org/jpos/gl/TestBase.java
@@ -84,9 +84,11 @@ public abstract class TestBase {
         try {
             String userName = System.getProperty("user.name");
             System.setProperty("user.name", "travis");
+            System.setProperty("db.create.enabled", "YES");
             new Import(configModifier).parse("../test-classes/testdata.xml");
             new Export(configModifier).export(System.out);
             System.setProperty("user.name", userName);
+            System.setProperty("db.create.enabled", "NO");
         } catch (Exception e) {
             e.printStackTrace();
             throw e;

--- a/modules/seqno/src/test/java/org/jpos/ee/SeqNoTest.java
+++ b/modules/seqno/src/test/java/org/jpos/ee/SeqNoTest.java
@@ -32,9 +32,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SeqNoTest {
     @BeforeAll
     public static void setUp() throws DocumentException {
+        System.setProperty("db.create.enabled", "YES");
         try (DB db = new DB()) {
             db.createSchema(null, true);
         }
+        System.setProperty("db.create.enabled", "NO");
     }
 
     @Test


### PR DESCRIPTION
DB.createSchema is a dangerous command. 

Make sure user knows what he's doing when running it.
