### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ notifications:
   slack:
     secure: HikbVVS4pi1VI1q0W0Kkh7NMXmrtDFw+ulqBpKA4VT+2LyOxsF18Bg+j40+hNonfTRPTuBYuOuU0wA79u1GBZRKdm2Ky3CGd1rohG53ONOk3I+J1K1W0hfzITZ+nkrB//+oAYJBADhZJQZ8PwjbhA4wxsz+k4XOaScwbTiemt8Y=
 matrix:
+  fast_finish: true
   include:
     - jdk: oraclejdk8
       dist: trusty
@@ -36,3 +37,8 @@ matrix:
     - jdk: openjdk9
     - jdk: openjdk10
 
+
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

According to the official document [Fast Finishing](https://docs.travis-ci.com/user/build-matrix/#fast-finishing), if some rows in the build matrix are allowed to fail, we can add fast_finish: true to the .travis.yml to get faster feedbacks.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
