### PR TITLE
Close session factories on DB.invalidateSessionFactories()

### DIFF
--- a/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
@@ -170,6 +170,11 @@ public class DB implements Closeable {
     }
 
     public static synchronized void invalidateSessionFactories() {
+        for (SessionFactory sf : sessionFactories.values()) {
+            try {
+                sf.close();
+            } catch (Exception ignored) {}
+        }
         sessionFactories.clear();
     }
 


### PR DESCRIPTION
This should allow database graceful shutdown procedure in combination with:

00_db_lifecycle.xml
```
<db-lifecycle class="org.jpos.ee.DatabaseLifecycle"/>
```

and 

org.jpos.ee.DatabaseLifecycle
```
package org.jpos.ee;

import org.jpos.q2.QBeanSupport;

public class DatabaseLifecycle extends QBeanSupport {

    @Override
    protected void stopService() throws Exception {
        DB.invalidateSessionFactories();
    }
}
```