### PR TITLE
Avoid NPE on createBalanceCache.

### DIFF
--- a/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
@@ -1549,6 +1549,10 @@ public class GLSession {
             c.setBalance (balance);
             session.saveOrUpdate (c);
         }
+
+        if (c.getBalance() == null) {
+            c.setBalance(balance);
+        }
         return c;
     }
 


### PR DESCRIPTION
With zero `maxId`, and if there didn't exist a `BalanceCache`. The created `BalanceCache` has a null `balance`, which in turn triggered an NPE on `getBalance0`.

Not sure if it should be:
```java
        if (maxId != c.getRef() || c.getBalance() == null) {
            c.setRef (maxId);
            c.setBalance (balance);
            session.saveOrUpdate (c);
        }
```
instead and save the balance cache or it's ok to delay the creation until `maxId > 0`, i.e. `getMaxGLEntryId()>SAFE_WINDOW`