### PR TITLE
make `Ping` class internationalization friendly

### DIFF
--- a/modules/status/src/main/java/org/jpos/ee/status/Ping.java
+++ b/modules/status/src/main/java/org/jpos/ee/status/Ping.java
@@ -18,6 +18,7 @@
 
 package org.jpos.ee.status;
 
+import java.net.ConnectException;
 import java.net.Socket;
 import java.io.IOException;
 import org.jpos.core.Configurable;
@@ -40,15 +41,12 @@ public class Ping extends Log implements MonitorTask, Configurable {
             socket.setSoLinger (true, 0);
             socket.close();
             rc = true;
+        } catch (ConnectException e) {
+            rc = true;
         } catch (IOException e) {
             String msg = e.getMessage().toUpperCase();
-            if (msg.indexOf ("CONNECTION REFUSED") >= 0) {
-                rc = true;
-            }
-            else {
-                rc = false;
-                detail = " " + msg;
-            }
+            rc = false;
+            detail = " " + msg;
         }
         long elapsed = System.currentTimeMillis() - start;
         return (rc ? Status.OK : Status.WARN) + detail 


### PR DESCRIPTION
`ConnectException` message `"CONNECTION REFUSED"` string depends on localization. So it would behave different in a jvm launched with non english language.

`Socket` constructor API doesn't specify `ConnectException`, but it will behave correctly on a more spread of installations. All jvm implementations throw it if connection refused.