### PR TITLE
Avoid NPE on createBalanceCache.

### DIFF
--- a/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
@@ -1543,6 +1543,9 @@ public class GLSession {
             c.setJournal (journal);
             c.setAccount (acct);
             c.setLayers (layersToString(layers));
+            c.setBalance(ZERO);     //Ensure we load a balance in the cache
+                                    //if maxId > 0 then the cache includes some entries, and
+                                    // we set the balance in the next if, before saving it.
         }
         if (maxId != c.getRef()) {
             c.setRef (maxId);


### PR DESCRIPTION
With zero `maxId`, and if there didn't exist a `BalanceCache`. The created `BalanceCache` had a null `balance`, which in turn triggered an NPE on `getBalance0`.

This PR ensures a non null balance is set for the newly created balance cache. It is set to ZERO, since if `maxId` is not zero the next if will set the correct balance, and if `maxId` is zero the correct balance is zero.