### PR TITLE
Avoid NPE in BLException.getDetailedMessage.

### DIFF
--- a/modules/core/src/main/java/org/jpos/ee/BLException.java
+++ b/modules/core/src/main/java/org/jpos/ee/BLException.java
@@ -61,8 +61,8 @@ public class BLException extends Exception implements Loggeable {
         return detail;
     }
     public String getDetailedMessage () {
-        StringBuffer sb = new StringBuffer (getMessage());
-
+        StringBuffer sb = new StringBuffer ();
+        sb.append(getMessage());
         if (detail != null) {
             sb.append (" (");
             sb.append (detail);


### PR DESCRIPTION
When `getMessage` is null.

This fix will generate the string `"null"` (or `"null(detail)"` if detail is not `null`) when `getMessage()` is null maybe we want another outcome, like empty string, but this feels more like the excpected behaviour for an exception message.