### PR TITLE
Q2Info handles /q2/mux/{muxname}/connected returning HTTP 503 if not connected

### DIFF
--- a/doc/src/asciidoc/book.adoc
+++ b/doc/src/asciidoc/book.adoc
@@ -9,7 +9,7 @@ jPOS Extended Edition
 :author: jPOS Software SRL
 :email: support@jpos.org
 :revdate: {localdate}
-:revnumber: 2.2.7-SNAPSHOT
+:revnumber: 2.2.9-SNAPSHOT
 :source-highlighter: rouge
 :listing-caption: Listing
 :pdf-page-size: A4
@@ -80,7 +80,7 @@ include::module_client_simulator.adoc[]
 include::module_sshd.adoc[]
 
 == Contributed modules
- 
+
 include::module_fsdmsgX.adoc[]
 
 //------------------------------------------------------------

--- a/modules/qrest/src/main/java/org/jpos/qrest/participant/Q2Info.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/participant/Q2Info.java
@@ -42,6 +42,8 @@ import static org.jpos.qrest.Constants.REQUEST;
 import static org.jpos.qrest.Constants.RESPONSE;
 
 public class Q2Info implements TransactionParticipant, Configurable {
+    // special temp key in response map to indicate a specific HttpResponseStatus value (should be removed from actual response)
+    private final static String HTTP_STATUS_KEY = "__http_status__";
     private TransactionManager txnmgr;
     private Q2 q2;
     private List<Route<Map<String,Object>>> routes = new ArrayList<>();
@@ -73,8 +75,14 @@ public class Q2Info implements TransactionParticipant, Configurable {
             }
             status = HttpResponseStatus.OK;
         }
-        if (response != null && response.containsKey("error")) {
-            status = HttpResponseStatus.NOT_ACCEPTABLE;
+
+        if (response != null) {
+            if (response.containsKey("error"))
+                status = HttpResponseStatus.NOT_ACCEPTABLE;
+            else if (response.containsKey(HTTP_STATUS_KEY)) {
+                status = (HttpResponseStatus) response.get(HTTP_STATUS_KEY);
+                response.remove(HTTP_STATUS_KEY);
+            }
         }
         ctx.put(RESPONSE,
           response != null ? new Response(status, response) :
@@ -136,6 +144,19 @@ public class Q2Info implements TransactionParticipant, Configurable {
         }
     }
 
+    private Map<String,Object> connected (Route r, String path) {
+        try {
+            QMUX qmux = (QMUX)QMUX.getMUX((String) r.parameters(path).get("muxname"));
+            Map<String,Object> m = muxInfo(qmux);
+            m.put(HTTP_STATUS_KEY,  qmux.isConnected()    ?
+                                    HttpResponseStatus.OK :
+                                    HttpResponseStatus.SERVICE_UNAVAILABLE);
+            return m;
+        } catch (NameRegistrar.NotFoundException e) {
+            return mapOf("error", e.getMessage() + " not found");
+        }
+    }
+
     private Map<String, Object> txnmgr () {
         List<Object> txnmgr =  NameRegistrar.getAsMap().entrySet()
                 .stream().filter(e -> e.getValue() instanceof TransactionManager)
@@ -170,6 +191,7 @@ public class Q2Info implements TransactionParticipant, Configurable {
         routes.add(new Route<>(prefix + "/q2/uptime**", "GET", (t,s) -> mapOf("uptime", q2.getUptime())));
         routes.add(new Route<>(prefix + "/q2/started**", "GET", (t,s) -> mapOf("started", new Date(System.currentTimeMillis() - q2.getUptime()))));
         routes.add(new Route<>(prefix + "/q2/diskspace**", "GET", (t,s) -> diskspace()));
+        routes.add(new Route<>(prefix + "/q2/mux/{muxname}/connected", "GET", (t,s) -> connected(t,s)));    // like below, but returns HTTP code 503 if mux not connected
         routes.add(new Route<>(prefix + "/q2/mux/{muxname}**", "GET", (t,s) -> muxInfo(t,s)));
         routes.add(new Route<>(prefix + "/q2/mux**", "GET", (t,s) -> muxes()));
         routes.add(new Route<>(prefix + "/q2/txnmgr/name", "GET", (t,s) -> mapOf("name", txnmgr.getName())));


### PR DESCRIPTION
The returned JSON is the same as with the url `/q2/mux/{muxname}`, but that version always returns `200 OK`
By adding the `/connected` part, it will return `503 Service Unavailable` when the mux is not connected.

This allows load balancers to do a health check without analyzing the returned JSON (which many of them can't easily do, or at all).