### PR TITLE
feat: Support for Environment to flyway service

### DIFF
--- a/doc/src/asciidoc/module_dbflyway.adoc
+++ b/doc/src/asciidoc/module_dbflyway.adoc
@@ -38,7 +38,7 @@ The migrate command accepts an optional --out-of-order parameter.
 
 In addition to CLI support, there's also a `FlywayService` that can be
 configured as a QBean. We recommend to use a low filename (such as
-`01_flyway.xml` so that the service starts before other services that may
+`01_flyway.xml`) so that the service starts before other services that may
 require the schema to be impacted in the database.
 
 The QBean descriptor looks like this:

--- a/modules/db-flyway/src/main/java/org/jpos/flyway/FlywayService.java
+++ b/modules/db-flyway/src/main/java/org/jpos/flyway/FlywayService.java
@@ -24,7 +24,7 @@ import org.flywaydb.core.api.MigrationInfoService;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.internal.info.MigrationInfoDumper;
 import org.jdom2.Element;
-import org.jpos.core.ConfigurationException;
+import org.jpos.core.Environment;
 import org.jpos.core.XmlConfigurable;
 import org.jpos.q2.QBeanSupport;
 
@@ -77,9 +77,7 @@ public class FlywayService extends QBeanSupport implements XmlConfigurable {
     }
 
     @Override
-    public void setConfiguration(Element e) throws ConfigurationException {
-        commands = e.getChildText("commands");
-        if (commands == null)
-            commands = "info";
+    public void setConfiguration(Element e) {
+        commands = Environment.get(e.getChildText("commands"), "info");
     }
 }

--- a/modules/db-flyway/src/test/java/org/jpos/flyway/FlywayServiceTest.java
+++ b/modules/db-flyway/src/test/java/org/jpos/flyway/FlywayServiceTest.java
@@ -1,0 +1,45 @@
+package org.jpos.flyway;
+
+import org.jdom2.Element;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Arturo Volpe
+ * @since 2022-05-12
+ */
+class FlywayServiceTest {
+
+    @Test
+    void test_empty_config() throws Exception {
+
+        FlywayService flywayService = new FlywayService();
+        flywayService.setConfiguration(new Element("flyway"));
+
+        assertEquals("info", flywayService.commands);
+    }
+
+    @Test
+    void test_static_config() throws Exception {
+
+        FlywayService flywayService = new FlywayService();
+        flywayService.setConfiguration(new Element("flyway")
+                .addContent(new Element("commands").addContent("info"))
+        );
+
+        assertEquals("info", flywayService.commands);
+    }
+
+    @Test
+    void test_env_config() throws Exception {
+
+        System.setProperty("flyway_commands", "info migrate");
+        FlywayService flywayService = new FlywayService();
+        flywayService.setConfiguration(new Element("flyway")
+                .addContent(new Element("commands").addContent("${flyway_commands}"))
+        );
+
+        assertEquals("info migrate", flywayService.commands);
+    }
+}


### PR DESCRIPTION
The FlywayService qbean is helpful to integrate flyway into the life cycle
of the server.

Normally we can migrate the schema automatically in development or local
environments, but in production normally we use a database user with
limited permissions (for example the user can't perform DDL -CREATE,
DROP-).

With this commit you can specify a property as the child of the
<command> tag:

```xml
<flyway class="org.jpos.flyway.FlywayService" logger="Q2">
    <property name="out-of-order" value="true" />
    <commands>${flyway_commands:validate}</commands>
</flyway>
```

This will allow setting an environment variable to local/dev environments
to perform migrations automatically (flyway_commands=migrate).

Signed-off-by: Arturo Volpe <arturovolpe@gmail.com>
