### PR TITLE
Update BinLog.java

### DIFF
--- a/modules/binlog/src/main/java/org/jpos/binlog/BinLog.java
+++ b/modules/binlog/src/main/java/org/jpos/binlog/BinLog.java
@@ -298,8 +298,10 @@ public abstract class BinLog implements AutoCloseable {
     }
 
     protected String getFirst(Path dir) throws IOException {
-        return StreamSupport.stream(Files.newDirectoryStream(dir, filePattern).spliterator(), false)
-                .map(Objects::toString).sorted(String::compareTo).findFirst().orElse(null);
+        try (DirectoryStream<Path> files = Files.newDirectoryStream(dir, filePattern)) {
+            return StreamSupport.stream(files.spliterator(), false)
+                    .map(Objects::toString).sorted(String::compareTo).findFirst().orElse(null);
+        }
     }
 
     private void verifyHeader(Path file, AsynchronousFileChannel raf) throws IOException {
@@ -331,16 +333,20 @@ public abstract class BinLog implements AutoCloseable {
     }
 
     private List<String> getFiles(Path dir) throws IOException {
-        return StreamSupport.stream(Files.newDirectoryStream(dir, filePattern).spliterator(), false)
-                .map(Objects::toString)
-                .sorted(String::compareTo)
-                .collect(Collectors.toList());
+        try (DirectoryStream<Path> files = Files.newDirectoryStream(dir, filePattern)) {
+            return StreamSupport.stream(files.spliterator(), false)
+                    .map(Objects::toString)
+                    .sorted(String::compareTo)
+                    .collect(Collectors.toList());
+        }
     }
     private List<String> getFilesReversed(Path dir) throws IOException {
-        return StreamSupport.stream(Files.newDirectoryStream(dir, filePattern).spliterator(), false)
-                .map(Objects::toString)
-                .sorted((s1, s2) -> -s1.compareTo(s2))
-                .collect(Collectors.toList());
+        try (DirectoryStream<Path> files = Files.newDirectoryStream(dir, filePattern)) {
+            return StreamSupport.stream(files.spliterator(), false)
+                    .map(Objects::toString)
+                    .sorted((s1, s2) -> -s1.compareTo(s2))
+                    .collect(Collectors.toList());
+        }
     }
 
     private boolean isClosed (Path f) throws IOException {


### PR DESCRIPTION
Fix Path file resource leak.   `Files.newDirectoryStream(dir, filePattern)` is a closeable resource and it opens a file path for the dir causing a fd leak.