### PR TITLE
feat: Add support for '.' on qrest path parameter

### DIFF
--- a/modules/qrest/src/main/java/org/jpos/qrest/Route.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/Route.java
@@ -89,7 +89,7 @@ public class Route<T> implements BiFunction<Route<T>, String,T> {
                 String name = m.group(i);
                 params.add(name);
                 s = m.replaceFirst(
-                  String.format("(?<%s>[^\\/.]*)", name)
+                  String.format("(?<%s>[^\\/]*)", name)
                 );
                 m.reset(s);
             }

--- a/modules/qrest/src/test/java/org/jpos/qrest/RouteTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/RouteTest.java
@@ -1,0 +1,40 @@
+package org.jpos.qrest;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Arturo Volpe
+ * @since 2022-11-27
+ */
+class RouteTest {
+
+    @Test
+    void matches() {
+
+
+        assertTrue(buildRoute("/simple").matches("/simple"));
+        assertTrue(buildRoute("/simpleWithSlash/").matches("/simpleWithSlash/"));
+        assertTrue(buildRoute("/withParam/{param1}/").matches("/withParam/1234/"));
+
+        // test path with dot
+        assertTrue(buildRoute("/{org}/{repo}/blob/{branch}/{file}").matches("/jpos/jPOS-EE/blob/master/README.md"));
+
+        // test path with dot (for example for version)
+        Route<?> path = buildRoute("/{version}/accounts/{code}");
+        String uri = "/2.1/accounts/21.001.001";
+        assertTrue(path.matches(uri));
+        Map<String, Object> params = path.parameters(uri);
+        assertEquals(2, params.size());
+        assertEquals("2.1", params.get("version"));
+        assertEquals("21.001.001", params.get("code"));
+    }
+
+    private static Route<String> buildRoute(String path) {
+        return new Route<>(path, "GET", (r, p) -> "");
+    }
+}


### PR DESCRIPTION
This commit adds support for path parameter that has dots ('.').

The dot is a commonly used path parameter, for example, all the URLs with
filenames have a dot for the extension.

I can't find any reference to support dots in this specification:

    https://www.rfc-editor.org/rfc/rfc6570

But in this specification:

    https://www.w3.org/Addressing/URL/url-spec.txt

When describing a [BNF](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form),
the dot is in the 'safe' rule, which is part of the 'segment' rule that
defines the 'path' of an URL.

Other use cases are:

* API Versioning: add the API version in the path, this is already
  partially supported with the wildcard (v2/*)
* minigl code: the mini account codes are a tree of all the parent
  accounts codes separated with a dot.

Signed-off-by: Arturo Volpe <avolpe@fintech.works>
