### PR TITLE
qrest: Response.contentType and byte[] body

### DIFF
--- a/modules/qrest/src/main/java/org/jpos/qrest/Response.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/Response.java
@@ -23,9 +23,16 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 public class Response {
     private HttpResponseStatus status;
     private Object body;
+    private String contentType;
+
     public Response(HttpResponseStatus status, Object body) {
+        this(status, body, null);
+    }
+
+    public Response(HttpResponseStatus status, Object body, String contentType) {
         this.status = status;
         this.body = body;
+        this.contentType = contentType;
     }
 
     public HttpResponseStatus status() {
@@ -36,10 +43,15 @@ public class Response {
         return body;
     }
 
+    public String contentType() {
+        return contentType;
+    }
+
     @Override
     public String toString() {
         return "Response{" +
           "status=" + status +
+          "contentType="+ contentType +
           ", body=" + body +
           '}';
     }


### PR DESCRIPTION
Two features
* `qrest.Response` may carry content type information.    
If available, it will be used when creating the http response (overriding other automagic smartness in `SendResponse` participant.    
It was the case that when the `Response` body was a `String` (instead of an object serialized by `ObjectMapper`), and `SendResponse` didn't have its  `content-type` property set, then no `content-type` would be sent in the http response.  Now the creator of the `Response` object has the chance to make the content type explicit.

* `qrest.SendResponse` handles a `byte[]` body directly, instead of having to do multiple String wrappings and unwrappings.    
For example, in the case of having to wrap the `byte []` output of a  `JSONPackager.pack()` in a String, only for it to be unrwapped again by `SendResponse`.  