### PR TITLE
TagsConverter: correctly handle null values

### DIFF
--- a/modules/dbsupport/src/main/java/org/jpos/ee/converter/TagsConverter.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/converter/TagsConverter.java
@@ -26,11 +26,15 @@ import javax.persistence.Converter;
 public class TagsConverter implements AttributeConverter<Tags,String> {
     @Override
     public String convertToDatabaseColumn(Tags tags) {
-        return tags != null && tags.size() > 0 ? tags.toString() : "";
+        return  tags == null ?
+                null :
+                tags.size() > 0 ? tags.toString() : "";
     }
 
     @Override
     public Tags convertToEntityAttribute(String dbData) {
-        return new Tags(dbData);
+        return  dbData != null ?
+                new Tags(dbData) :
+                null;
     }
 }


### PR DESCRIPTION
The `TagsConverter` was persisting a Java `null` as an empty string.
Also, when retrieving a `null` from the DB, it was converting it to an empty `Tags` instance.

Among other problems, this gave errors when `equals()` comparing an entity with a `Tags` field retrieved from the DB against one that still had its in-memory`null`.
