### PR TITLE
Set DB user and password read from Space in Properties

### DIFF
--- a/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
@@ -569,10 +569,14 @@ public class DB implements Closeable {
                     Space sp = SpaceFactory.getSpace("tspace:dbconfig");
                     String user = (String) sp.inp(dbPropertiesPrefix +"connection.username");
                     String pass = (String) sp.inp(dbPropertiesPrefix +"connection.password");
-                    if (user != null)
+                    if (user != null) {
                         ssrb.applySetting("hibernate.connection.username", user);
-                    if (pass != null)
+                        dbProps.setProperty("hibernate.connection.username", user);
+                    }
+                    if (pass != null) {
                         ssrb.applySetting("hibernate.connection.password", pass);
+                        dbProps.setProperty("hibernate.connection.password", pass);
+                    }
                 }
                 MetadataSources mds = new MetadataSources(ssrb.build());
 


### PR DESCRIPTION
Other modules like Flyway that read db properties from DB class do not see the username and password set via DBInstantiator. This PR fixes that by adding those to dbProps in DB.