### PR TITLE
Let database properties be loaded from classpath.

### DIFF
--- a/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
@@ -260,11 +260,16 @@ public class DB implements Closeable {
 
     private Properties loadProperties(String filename) throws IOException {
         Properties props = new Properties();
-        final String s = filename.replaceAll("/", "\\" + File.separator);
-        final File f = new File(s);
-        if (f.exists()) {
-            try (FileReader fr = new FileReader(f)) {
-                props.load(fr);
+        if (filename.startsWith("jar:") && filename.length()>4) {
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            props.load(cl.getResourceAsStream(filename.substring(4)));
+        } else {
+            final String s = filename.replaceAll("/", "\\" + File.separator);
+            final File f = new File(s);
+            if (f.exists()) {
+                try (FileReader fr = new FileReader(f)) {
+                    props.load(fr);
+                }
             }
         }
         return props;


### PR DESCRIPTION
If `DB_PROPERTIES` value starts with `jar:` it will load the database properties from the classpath instead of from the filesystem

Implements #287.