### PR TITLE
Avoid long-lived reference to DOM Element within lambda closure

### DIFF
--- a/modules/qrest/src/main/java/org/jpos/qrest/participant/Router.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/participant/Router.java
@@ -72,13 +72,14 @@ public class Router implements GroupSelector, XmlConfigurable {
     public void setConfiguration(Element e) throws ConfigurationException {
         try {
             for (Element r : e.getChildren("route")) {
+                String name = r.getAttributeValue("name");
                 routes.computeIfAbsent(
                   r.getAttributeValue("method"),
                   k -> new ArrayList<>()).add(
                     new Route<>(
                       r.getAttributeValue("path"),
                       r.getAttributeValue("method"),
-                      (t, s) -> r.getAttributeValue("name"))
+                      (t, s) -> name)
                 );
             }
         } catch (Throwable t) {


### PR DESCRIPTION
A reference to the `Element` (therefore, to the whole DOM tree) was held by the long-lived and lazily-evaluated lambda closure.

This fix is more a "matter of principles", since the whole `persist` DOM is still being held by the `QBean` itself during its lifetime. But it's a saner pattern not to hold on to unneeded references for too long.