### PR TITLE
Migrating Jetty and http-client modules to next

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ jetty = '12.0.6'
 jetty11 = '11.0.20'
 jetty9 = '9.4.53.v20231009'
 webSocketApi = '1.1'
+httpAsyncClient = '4.1.5'
 
 [libraries]
 jpos = { module = "org.jpos:jpos", version.ref = "jpos" }
@@ -55,3 +56,4 @@ webSocketApi = { module = 'javax.websocket:javax.websocket-api', version.ref = '
 #jettyWebsocketJsr356 = { module = 'org.eclipse.jetty.websocket:javax-websocket-server-impl', version.ref = 'jetty9'  }
 #jettyServlets = { module = 'org.eclipse.jetty:jetty-servlets', version.ref = 'jetty11'  }
 #jettyContinuation = { module = 'org.eclipse.jetty:jetty-continuation', version.ref = 'jetty9'  }
+httpAsyncClient = { module = 'org.apache.httpcomponents:httpasyncclient', version.ref = 'httpAsyncClient' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,10 @@ freemarker = '2.3.32'
 jsonSchemaValidator = '2.2.14'
 guava = '33.0.0-jre'
 jakartaActivation = '2.0.1'
+jetty = '12.0.6'
+jetty11 = '11.0.20'
+jetty9 = '9.4.53.v20231009'
+webSocketApi = '1.1'
 
 [libraries]
 jpos = { module = "org.jpos:jpos", version.ref = "jpos" }
@@ -33,4 +37,21 @@ freemarker = { module = 'org.freemarker:freemarker', version.ref = 'freemarker' 
 jsonSchemaValidator = { module = 'com.github.java-json-tools:json-schema-validator', version.ref = 'jsonSchemaValidator' }
 guava = { module = 'com.google.guava:guava', version.ref = 'guava' }
 jakartaActivation = { module = 'com.sun.activation:jakarta.activation', version.ref = 'jakartaActivation' }
-
+jettyServer = { module = 'org.eclipse.jetty:jetty-server', version.ref = 'jetty' }
+jettyXml = { module = 'org.eclipse.jetty:jetty-xml', version.ref = 'jetty' }
+jettyDeploy = { module = 'org.eclipse.jetty:jetty-deploy', version.ref = 'jetty' }
+jettyJmx = { module = 'org.eclipse.jetty:jetty-jmx', version.ref = 'jetty' }
+jettySecurity = { module = 'org.eclipse.jetty:jetty-security', version.ref = 'jetty' }
+jettyRewrite = { module = 'org.eclipse.jetty:jetty-rewrite', version.ref = 'jetty' }
+jettyUtil = { module = 'org.eclipse.jetty:jetty-util', version.ref = 'jetty' }
+jettyPlus = { module = 'org.eclipse.jetty:jetty-plus', version.ref = 'jetty' }
+jettyJndi = { module = 'org.eclipse.jetty:jetty-jndi', version.ref = 'jetty' }
+jettyPolicy = { module = 'org.eclipse.jetty:jetty-policy', version.ref = 'jetty' }
+jettyAjp = { module = 'org.eclipse.jetty:jetty-ajp', version.ref = 'jetty' }
+webSocketApi = { module = 'javax.websocket:javax.websocket-api', version.ref = 'webSocketApi' }
+#jettyWebapp = { module = 'org.eclipse.jetty:jetty-webapp', version.ref = 'jetty11'  }
+#jettyAnnotations = { module = 'org.eclipse.jetty:jetty-annotations', version.ref = 'jetty11'  }
+#jettyWebsocket = { module = 'org.eclipse.jetty.websocket:websocket-server', version.ref = 'jetty9'  }
+#jettyWebsocketJsr356 = { module = 'org.eclipse.jetty.websocket:javax-websocket-server-impl', version.ref = 'jetty9'  }
+#jettyServlets = { module = 'org.eclipse.jetty:jetty-servlets', version.ref = 'jetty11'  }
+#jettyContinuation = { module = 'org.eclipse.jetty:jetty-continuation', version.ref = 'jetty9'  }

--- a/modules/http-client/build.gradle
+++ b/modules/http-client/build.gradle
@@ -1,12 +1,10 @@
 description = 'jPOS-EE :: QRest Client'
 
 dependencies {
-    api libraries.jpos
-    api libraries.httpAsyncClient
+    api libs.jpos
+    api libs.httpAsyncClient
     testImplementation project(':modules:qrest')
 }
-
-apply from: "${rootProject.projectDir}/jpos-app.gradle"
 
 test {
     dependsOn('installApp')

--- a/modules/jetty/build.gradle
+++ b/modules/jetty/build.gradle
@@ -2,7 +2,19 @@ description = 'jPOS-EE :: Jetty Web Module'
 
 dependencies {
     api project(':modules:core')
-    api jettyLibs
-    api "javax.websocket:javax.websocket-api:${websocketApiVersion}"
+    api libs.jettyServer
+    api libs.jettyXml
+    api libs.jettyJmx
+    api libs.jettyDeploy
+    api libs.jettySecurity
+    api libs.jettyUtil
+    api libs.jettyRewrite
+    api libs.webSocketApi
+//    api libs.jettyAnnotations
+//    api libs.jettyWebapp
+//    api libs.jettyWebsocket
+//    api libs.jettyWebsocketJsr356
+//    api libs.jettyContinuation
+//    api libs.jettyServlets
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,7 @@ include  ':modules:quartz'
 include  ':modules:bom'
 include  ':modules:logback'
 include  ':modules:qrest'
+include  ':modules:jetty'
 
 dependencyResolutionManagement {
     versionCatalogs {

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,7 @@ include  ':modules:bom'
 include  ':modules:logback'
 include  ':modules:qrest'
 include  ':modules:jetty'
+include  ':modules:http-client'
 
 dependencyResolutionManagement {
     versionCatalogs {


### PR DESCRIPTION
Jetty libraries version upgraded to 12.0.6. Some of the dependencies that are not available at that version have been omitted for now. They can be added back if needed, whenever they are available at v12.0.6
