### PR TITLE
Update reference to jLine.

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -13,7 +13,7 @@ ext {
     guavaVersion = '31.0.1-jre'
     jacksonVersion = '2.10.5.1'
     groovyVersion = '3.0.4'
-    jlineVersion = '2.14.6'
+    jlineVersion = '3.23.0'
     restAssuredVersion = '2.9.0'
     vaadinVersion = '8.14.1'
     nettyVersion = '4.1.73.Final'

--- a/modules/groovy/build.gradle
+++ b/modules/groovy/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     api libraries.groovy
     api libraries.groovysh
     implementation libraries.jline
-    api group: 'org.fusesource.jansi', name: 'jansi', version: '1.11'
 
     api libraries.groovySql
 }


### PR DESCRIPTION
This PR updates the reference to jLine to version 3.23.0 so as to avoid a conflict in the underlying reference to jansi.

Also, it removes an explicit reference to jansi, which is unnecesary since it is part of jLine (as a dependency).

See jLine dependencies at https://mvnrepository.com/artifact/org.jline/jline/3.23.0. 