### PR TITLE
bump groovy to 3.0.21 and reintroduce a much newer jansi 2.4.1

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -12,7 +12,7 @@ ext {
     jsonSchemaVersion = '2.2.11'
     guavaVersion = '31.0.1-jre'
     jacksonVersion = '2.10.5.1'
-    groovyVersion = '3.0.4'
+    groovyVersion = '3.0.21'
     jlineVersion = '3.23.0'
     restAssuredVersion = '2.9.0'
     vaadinVersion = '8.14.1'

--- a/modules/groovy/build.gradle
+++ b/modules/groovy/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     api libraries.groovy
     api libraries.groovysh
     implementation libraries.jline
+    api group: 'org.fusesource.jansi', name: 'jansi', version: '2.4.1'
 
     api libraries.groovySql
 }


### PR DESCRIPTION
This fixes some `q2 -cli` problems on Linux systems.
groovy 3.0.21 is the latest one from the `3.0.x` branch, and it should not break anything