### PR TITLE
Sugar for Configuration access in Groovy.

### DIFF
--- a/modules/groovy/src/main/resources/org/jpos/groovy/JPOSGroovyDefaults.groovy
+++ b/modules/groovy/src/main/resources/org/jpos/groovy/JPOSGroovyDefaults.groovy
@@ -23,6 +23,7 @@ import groovy.transform.Field
 
 import org.jpos.transaction.Context
 import org.jpos.util.Caller
+import org.jpos.core.Configuration
 
 
 // ### Groovy initialization to spice up Context object
@@ -46,6 +47,17 @@ ctxmc.putAt= { Object key, Object val ->
     delegate.put(key, val)
 }
 
+// ### Groovy initialization to spice up Configuration.
+
+def cfgmc = Configuration.metaClass
+
+cfgmc.getProperty = { String name ->
+    return delegate.get(name)
+}
+
+cfgmc.getAt= { Object key ->
+    return delegate.get(key)
+}
 
 // ### Groovy alternatives for org.jpos.util.Caller#info() methods
 


### PR DESCRIPTION
This PR, just adds a convenient way to reference configuration String properties.

A nice addition would be to call `getXXX` by using method overloading by return type, that, even when java doesn't allow it, the JVM does.  I kind of remember having read somewhere that groovy does, but I'm not sure, and I couldn't find the syntax.

It doesn't have much sense to worry about it anyway if there isn't a use case for that.