### PR TITLE
Add missing `type` property in Syslog documentation.

### DIFF
--- a/doc/src/asciidoc/entities/syslog.adoc
+++ b/doc/src/asciidoc/entities/syslog.adoc
@@ -7,6 +7,7 @@ class SysLog {
   int id;
   Date date;
   String source;
+  String type;
   int severity;
   String summary;
   String detail;
@@ -25,6 +26,7 @@ The table has the following columns:
 - `date`: timestamp
 - `deleted`: logical delete indicator
 - `source`: application specific source (i.e. node name)
+- `type`: logical event group (i.e. "SYSTEM", "SECURITY", etc.)
 - `severity`: we use DEBUG = 0, TRACE = 1, INFO  = 2, WARN  = 3, ERROR = 4, CRITICAL=5
 - `summary`: a brief description of the event, suitable to be printed by the UI in a column
 - `detail`: specific info about the event


### PR DESCRIPTION
Ditto.