### PR TITLE
VariableFieldPackager NPE on msg.pack followed by hexdump  when field is not set and only the dlimiter is expected in the stream

### DIFF
--- a/modules/fsdmsgx/src/main/java/org/jpos/fsdpackager/VariableFieldPackager.java
+++ b/modules/fsdmsgx/src/main/java/org/jpos/fsdpackager/VariableFieldPackager.java
@@ -85,6 +85,7 @@ public class VariableFieldPackager extends AFSDFieldPackager {
 		if (value == null || value.equals("")) {
 			// if field is not set, make sure to send the delimiter to indicate
 			// its presence.
+			setValue(""); // the field needs to be set with a empty string in case it was null.
 			return new byte[] { delimiter.byteValue() };
 		}
 		if (value.length() <= maxSize) {


### PR DESCRIPTION
The value needs to be set with an empty string if the user did not set it specifically and was null. This mimics unpack where value is set to "" when only a delimiter is found. Due to this not being set in pack, the hexdump called on the msg after pack, results in a NPE.

```
        VariableFieldPackager f1  = new VariableFieldPackager("F1", 20, Byte.valueOf((byte) 0x1c),
                                                              AsciiInterpreter.INSTANCE);

        FSDMsgX               msg = new FSDMsgX("Test1");
        msg.add("F1", f1);


        byte[] arr = msg.pack();

        System.out.println(msg.getParserTree(""));
        System.out.println(msg.hexDump(""));
```

Output 

```
[Test1]
Field [F1] : VAR[0..20] delimiter[0x1C] or EOM  : 

0000  1C                                                .



```