### PR TITLE
FixedFieldPackager pack padding was not being used

### DIFF
--- a/modules/fsdmsgx/src/main/java/org/jpos/fsdpackager/FixedFieldPackager.java
+++ b/modules/fsdmsgx/src/main/java/org/jpos/fsdpackager/FixedFieldPackager.java
@@ -89,10 +89,10 @@ public class FixedFieldPackager extends  AFSDFieldPackager {
 		}
 		if (value.length() <= size) {
 			if (padLeft){
-				ISOUtil.padleft(getValue(), size,(char) padCharacter.byteValue() );
+				value = ISOUtil.padleft(getValue(), size,(char) padCharacter.byteValue() );
 			}
 			else {
-				ISOUtil.padright(getValue(), size,(char) padCharacter.byteValue() );
+				value = ISOUtil.padright(getValue(), size,(char) padCharacter.byteValue() );
 			}
 		}
 		else {


### PR DESCRIPTION
The pack method was padding the value but the padded value was not being used.

```
        FixedFieldPackager f1 = new FixedFieldPackager("F1", 20,
                                                              AsciiInterpreter.INSTANCE);

        FSDMsgX               msg = new FSDMsgX("Test1");
        msg.add("F1", f1);

        msg.set("F1", "1234");


        byte[] arr = msg.pack();

        System.out.println(msg.getParserTree(""));
        System.out.println(msg.hexDump(""));

```

Output . You can see the space padding now. Before you would just see 1234

```
[Test1]
Field [F1] : Fixed [20] :                 1234

0000  20 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20                  
0010  31 32 33 34                                       1234



```