### PR TITLE
Feature/multitenancy

### DIFF
--- a/modules/eeuser/src/main/java/org/jpos/ee/Realm.java
+++ b/modules/eeuser/src/main/java/org/jpos/ee/Realm.java
@@ -43,6 +43,9 @@ public class Realm extends Cloneable implements Serializable {
     @Column(length=8000)
     private String description;
 
+    @Column(length=64)
+    private String reference;
+
     public Long getId() {
         return id;
     }
@@ -66,6 +69,10 @@ public class Realm extends Cloneable implements Serializable {
     public void setDescription(String description) {
         this.description = description;
     }
+
+    public String getReference() { return reference; }
+
+    public void setReference(String reference) { this.reference = reference; }
 
     public Realm() {
         super();

--- a/modules/eeuser/src/main/java/org/jpos/ee/User.java
+++ b/modules/eeuser/src/main/java/org/jpos/ee/User.java
@@ -145,10 +145,24 @@ public class User extends Cloneable implements Serializable, SoftDelete {
         this.loginAttempts++;
     }
     public boolean hasPermission (String permName) {
+        return hasPermission(permName,null);
+    }
+
+    public boolean hasPermission(String permName, String reference) {
         if (permName != null) {
             for (Role r : roles) {
-                if (r.hasPermission(permName))
+                String realmReference = r.getRealm() != null ? r.getRealm().getReference() : null;
+                boolean referenceMatch;
+                if (reference == null) {
+                    // Null reference requires realm reference to be null or empty
+                    referenceMatch = (realmReference == null || realmReference.isEmpty());
+                } else {
+                    // Non-null reference requires exact match (case-insensitive)
+                    referenceMatch = (realmReference != null && realmReference.equalsIgnoreCase(reference));
+                }
+                if (referenceMatch && r.hasPermission(permName)) {
                     return true;
+                }
             }
         }
         return false;
@@ -156,10 +170,7 @@ public class User extends Cloneable implements Serializable, SoftDelete {
     public boolean hasAnyPermission (String[] permNames) {
         if (permNames != null) {
             for (String p : permNames) {
-                for (Role r : roles) {
-                    if (r.hasPermission(p))
-                        return true;
-                }
+                hasPermission(p);
             }
         }
         return false;
@@ -167,12 +178,7 @@ public class User extends Cloneable implements Serializable, SoftDelete {
     public boolean hasAllPermissions (String[] permNames) {
         if (permNames != null) {
             for (String p : permNames) {
-                boolean hasPerm = false;
-                for (Role r : roles) {
-                    if (r.hasPermission(p))
-                        hasPerm = true;
-                }
-                if (!hasPerm)
+                if (!hasPermission(p))
                     return false;
             }
             return true;


### PR DESCRIPTION
Adds a reference to Realm, so we could add an entity reference to the role, and have entity based permissions. 

Now when checking for a permission, we can also include a reference to an entity that needs to match the reference from the role's realm. If no reference is sent, then the role must not have a realm or a reference. 