### PR TITLE
bump: jPOS 3.0.1-SNAPSHOT → 3.0.2-SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jpos = "3.0.1-SNAPSHOT"
+jpos = "3.0.2-SNAPSHOT"
 commonsLang3 = "3.20.0"
 quartz = "2.5.2"
 slf4j = "2.0.17"


### PR DESCRIPTION
Updates `gradle/libs.versions.toml` to depend on jPOS `3.0.2-SNAPSHOT`.