### PR TITLE
bump: upgrade jPOS Gradle plugin 0.0.15 → 0.0.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jpos.jposapp' version '0.0.15'
+    id 'org.jpos.jposapp' version '0.0.17'
     id 'idea'
     id 'org.gradlex.extra-java-module-info' version '1.9'
     id 'org.owasp.dependencycheck' version '12.1.3'


### PR DESCRIPTION
Bumps the jPOS Gradle plugin from `0.0.15` to `0.0.17` in `build.gradle`.

**What's new in 0.0.16–0.0.17:**
- `extraPaths` configuration for `distnc`/`zipnc` tasks
- `GitRevisionTask` now uses `FileRepositoryBuilder.findGitDir()` — works correctly in multi-module repos (like jPOS-EE itself) and non-git projects
- Exec permissions fix for `dist/bin` files
- Toolchain upgrade to Java 25.0.2-amzn / Gradle 9.4.0

**Build status:** `BUILD SUCCESSFUL` ✅ (286 tasks). The two skipped test modules (`seqno`, `cryptoservice-kafka`) have pre-existing failures unrelated to this bump.