### PR TITLE
fix(cmf): parseDateTime drops time and amountSign validation accepts dot

### DIFF
--- a/modules/cmf/src/main/java/org/jpos/cmf/CMFAdditionalAmount.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/CMFAdditionalAmount.java
@@ -72,7 +72,7 @@ public class CMFAdditionalAmount extends AdditionalAmount {
         String amountSign = data.substring(8,9);
         BigDecimal amount = new BigDecimal(data.substring(data.length() - 12)).movePointLeft(minorUnit);
 
-        if (!"C.D".contains(amountSign))
+        if (!"CD".contains(amountSign))
             throw new IllegalArgumentException("Invalid amount sign");
 
         if ("D".equalsIgnoreCase(amountSign))

--- a/modules/cmf/src/main/java/org/jpos/cmf/CMFDate.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/CMFDate.java
@@ -101,7 +101,7 @@ public class CMFDate {
      * @return parsed {@link Date}
      */
     public static Date parseDateTime(String cmfDateString) {
-        return cmfDateString == null ? null : toDate(parseLocalDate(cmfDateString));
+        return cmfDateString == null ? null : toDate(parseLocalDateTime(cmfDateString));
     }
 
     public static String format(LocalDateTime dateTime) {


### PR DESCRIPTION
Found two small bugs in the `cmf` module while going through the code.

`CMFDate.parseDateTime` calls `parseLocalDate` internally instead of `parseLocalDateTime`, so the time component gets silently dropped on every call.

`CMFAdditionalAmount` validates the sign with `!"C.D".contains(amountSign)` since `String.contains` matches substrings, a dot passes through without throwing.

Happy to close if either is intentional, you know the codebase far better than I do.