### PR TITLE
build(deps): bump AWS SDK and Ehcache

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,11 +25,11 @@ httpClient = '5.6'
 jgroups = '5.5.4.Final'
 xmlBind = "4.0.5"
 javaxCache = '1.1.1'
-ehCache = '3.11.1'
+ehCache = '3.12.0'
 jetty = '12.1.8'
 groovy = '3.0.25'
 kafka = '4.2.0'
-awssdk = '2.42.12'
+awssdk = '2.42.33'
 jakartaWsRs = '4.0.0'
 
 [libraries]


### PR DESCRIPTION
## Summary
- bump AWS Payment Cryptography SDK from 2.42.12 to 2.42.33
- bump Ehcache from 3.11.1 to 3.12.0
