### PR TITLE
fix(CRUD): handle null entity id in canPost

### DIFF
--- a/modules/qrest-crud/src/main/java/org/jpos/qrest/crud/participant/CRUD.java
+++ b/modules/qrest-crud/src/main/java/org/jpos/qrest/crud/participant/CRUD.java
@@ -267,7 +267,10 @@ public abstract class CRUD<T, I, O> implements TransactionParticipant, Configura
     protected boolean canPost(Context ctx, T entity) {
         DB db = ctx.get(TxnSupport.DB);
         try {
-            Object persistedEntity = db.session().get(entity.getClass(), getId(entity));
+            Object id = getId(entity);
+            if (id == null)
+                return true;
+            Object persistedEntity = db.session().get(entity.getClass(), id);
             if (persistedEntity != null) {
                 ctx.put(TEMP_RESPONSE, new Response(HttpResponseStatus.CONFLICT, new RestErrorResponse("duplicate.id")));
                 return false;


### PR DESCRIPTION
Hibernate's session.get() throws IllegalArgumentException ("id to load is required for loading") when passed a null identifier. CRUD.canPost() invoked it unconditionally with getId(entity), which is null for POST requests targeting entities with server-generated IDs — the normal case.

As a result, every subclass that wanted to support POST had to override canPost() solely to avoid this crash, even when no custom logic was needed.

Skip the duplicate-id lookup when the entity id is null. A null id cannot collide with an existing row, so returning true is correct. Consumers that want to forbid client- provided ids on POST can still enforce that in their own override.