### PR TITLE
ci: avoid duplicate workflow runs on branch pushes

### DIFF
--- a/.github/workflows/jpos-ee.yml
+++ b/.github/workflows/jpos-ee.yml
@@ -1,6 +1,10 @@
 ---
 name: "Run jPOS-EE Tests"
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Restrict the `jpos-ee.yml` workflow triggers to avoid duplicate CI runs for the same change.

## Change

Replace:

```yaml
on: [push, pull_request]
```

with:

```yaml
on:
  push:
    branches: [ main ]
  pull_request:
    branches: [ main ]
```

## Why

Right now the workflow runs the same build twice for a typical PR branch update:

- once on `push`
- once on `pull_request`

Since the workflow contains a single `build` job with the same steps in both cases, this duplicates CI work and noise without adding coverage.

This change keeps:

- PR validation for changes targeting `main`
- CI on changes pushed or merged to `main`

while avoiding redundant runs for feature branches.

## Notes

There is also a `GRADLE_OPTS=-Dtest.minigl_db_driver=postgres` environment variable attached only to the artifact upload step. That appears unrelated to actual test execution and may be worth revisiting separately, but this PR does not change it.
