### PR TITLE
ci: move artifact upload action to Node 24-compatible version

### DIFF
--- a/.github/workflows/jpos-ee.yml
+++ b/.github/workflows/jpos-ee.yml
@@ -32,7 +32,7 @@ jobs:
         TERM: dumb
     - name: Upload test results
       if: success() || failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-results-${{ matrix.java }}-${{ matrix.os }}
         path: modules/*/build/reports/tests/*


### PR DESCRIPTION
This updates the remaining GitHub Actions dependency in jPOS-EE that still runs on Node 20.

Why:
- recent jPOS-EE workflow runs emitted GitHub's Node 20 deprecation warning
- jPOS-EE itself is not using Node directly, the warning comes from a JavaScript-based GitHub Action
- `actions/upload-artifact@v4` in `jpos-ee.yml` still runs on Node 20

Change:
- `actions/upload-artifact@v4` -> `@v7`

This moves the workflow to a Node 24-compatible artifact upload action and should eliminate the deprecation warning on future runs.
