### PR TITLE
test: add default Agroal pool sizing to DB install templates

### DIFF
--- a/modules/db-h2/src/main/resources/META-INF/q2/installs/cfg/db.properties
+++ b/modules/db-h2/src/main/resources/META-INF/q2/installs/cfg/db.properties
@@ -23,4 +23,6 @@ hibernate.connection.password=
 #
 hibernate.connection.url=jdbc:h2:./data/jposee;LOCK_TIMEOUT=5000
 hibernate.connection.driver_class=org.h2.Driver
+hibernate.agroal.minSize=1
+hibernate.agroal.maxSize=8
 

--- a/modules/db-mysql/src/main/resources/META-INF/q2/installs/cfg/db.properties
+++ b/modules/db-mysql/src/main/resources/META-INF/q2/installs/cfg/db.properties
@@ -23,4 +23,6 @@ hibernate.connection.password=password
 hibernate.connection.url=jdbc:mysql://localhost/jposee?autoReconnect=true
 hibernate.connection.driver_class=com.mysql.cj.jdbc.Driver
 hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
+hibernate.agroal.minSize=1
+hibernate.agroal.maxSize=100
 #

--- a/modules/db-postgresql/src/main/resources/META-INF/q2/installs/cfg/db.properties
+++ b/modules/db-postgresql/src/main/resources/META-INF/q2/installs/cfg/db.properties
@@ -22,6 +22,8 @@ hibernate.connection.password=password
 #
 hibernate.connection.url=jdbc:postgresql://localhost:5432/jposee
 hibernate.connection.driver_class=org.postgresql.Driver
+hibernate.agroal.minSize=1
+hibernate.agroal.maxSize=100
 #
 hibernate.connection.pool_size=100
 

--- a/modules/eeuser/src/test/java/org/jpos/ee/EEUserTest.java
+++ b/modules/eeuser/src/test/java/org/jpos/ee/EEUserTest.java
@@ -121,7 +121,9 @@ class EEUserTest {
 
     @AfterEach
     public void tearDown() {
-        db.close();
+        if (db != null) {
+            db.close();
+        }
     }
 
     private Role createRole (DB db, Realm realm, String name, String... permissions) {


### PR DESCRIPTION
This follows up the Agroal upgrade by fixing test/runtime DB configurations that now initialize Hibernate through Agroal without required pool sizing properties.

Root cause:
- `EEUserTest` was failing with:
  - `java.lang.IllegalArgumentException: max size attribute is mandatory`
- the generated `cfg/db.properties` from the install templates did not include default `hibernate.agroal.*` pool sizing
- with `hibernate-agroal` now on the classpath, modules using the default installed DB config can fail even if they do not explicitly set `hibernate.connection.provider_class`

Changes:
- add default Agroal pool sizing to install templates:
  - `modules/db-h2/.../cfg/db.properties`
  - `modules/db-postgresql/.../cfg/db.properties`
  - `modules/db-mysql/.../cfg/db.properties`
- harden `EEUserTest.tearDown()` against null `db` after setup failure

Validation:
- `source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk env install && sdk env && ./gradlew --no-daemon :modules:eeuser:test :modules:seqno:test :modules:minigl:test` ✅

Notes:
- this addresses the failing Agroal test regression
- PR workflows are running correctly on jPOS-EE; the earlier problem was red tests, not missing PR execution
