### PR TITLE
Update q2 launcher script

### DIFF
--- a/modules/cryptoserver/src/dist/bin/q2
+++ b/modules/cryptoserver/src/dist/bin/q2
@@ -1,25 +1,78 @@
-#!/bin/sh
+#!/bin/bash
 
-cd `dirname $0`/.. || exit 1
+set -euo pipefail
+cd "$(dirname "$0")/.." || exit 1
 rm -f deploy/shutdown.xml
 
-if [ -f jpos.pid ] && ps -p $(cat jpos.pid) > /dev/null 2>&1
-then
-   echo "Process $(cat jpos.pid) is running"
-else
-    rm -f jpos.pid
-    exec java -server \
-        -XX:+IgnoreUnrecognizedVMOptions \
-        -Xmx1G \
-        -Xloggc:log/gc.log \
-        -XX:+PrintGCDetails \
-        -XX:+PrintGCDateStamps \
-        -XX:+UseGCLogFileRotation \
-        -XX:NumberOfGCLogFiles=5 \
-        -XX:GCLogFileSize=2M \
-        -XX:NumberOfGCLogFiles=5 \
-        -Djava.net.preferIPv4Stack=true \
-        -Dcom.sun.management.jmxremote \
-        -jar jposee-@jarname@ --pid-file='jpos.pid' "$@"
+INHERITED_JAVA_OPTS="${JAVA_OPTS:-}"
+EXTRA_JAVA_OPTS=()
+EXTRA_OTHER_OPTS=()
+
+PID_FILE="jpos.pid"
+USE_PID=true
+
+for arg in "$@"; do
+  case "$arg" in
+    -D*)
+      EXTRA_JAVA_OPTS+=("$arg")
+      ;;
+    --pid=*)
+      PID_FILE="${arg#--pid=}"
+      ;;
+    --no-pid)
+      USE_PID=false
+      ;;
+    --debug)
+      EXTRA_JAVA_OPTS+=("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
+      ;;
+    *)
+      EXTRA_OTHER_OPTS+=("$arg")
+      ;;
+  esac
+done
+
+if $USE_PID; then
+  if [ -f "$PID_FILE" ] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
+    echo "Process $(cat "$PID_FILE") is running"
+    exit 1
+  fi
+  rm -f "$PID_FILE"
 fi
 
+mkdir -p log
+
+# Locate Java via JAVA_HOME or SDKMAN
+if [ -z "${JAVA_HOME:-}" ]; then
+  SDKMAN_JAVA="$HOME/.sdkman/candidates/java/current"
+  if [ -d "$SDKMAN_JAVA" ]; then
+    export JAVA_HOME="$SDKMAN_JAVA"
+  fi
+fi
+
+# Base JVM invocation. Order matters: every JVM flag (-D, -X, --add-*,
+# agent flags from --debug, INHERITED_JAVA_OPTS from the env var) MUST
+# land before -jar @jarname@. Anything after -jar is treated as a
+# program argument by Java and triggers "Unrecognized option".
+JAVA_CMD="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+
+ENV_JAVA_OPTS=( ${INHERITED_JAVA_OPTS} )
+
+CMD=(
+  "$JAVA_CMD" -server
+  -Xmx4G
+  --enable-native-access=ALL-UNNAMED
+  --sun-misc-unsafe-memory-access=allow
+  -Xlog:gc:log/gc.log
+)
+# JVM flags: in-script defaults first, then env-supplied, then CLI -D.
+CMD+=( ${ENV_JAVA_OPTS[@]+"${ENV_JAVA_OPTS[@]}"} )
+CMD+=( ${EXTRA_JAVA_OPTS[@]+"${EXTRA_JAVA_OPTS[@]}"} )
+# Now the jar selector itself.
+CMD+=( -jar @jarname@ )
+# Program args — these go to Q2's main, not the JVM.
+if $USE_PID; then
+  CMD+=( --pid="$PID_FILE" )
+fi
+CMD+=( ${EXTRA_OTHER_OPTS[@]+"${EXTRA_OTHER_OPTS[@]}"} )
+
+exec "${CMD[@]}"

--- a/modules/db-liquibase/src/dist/bin/q2
+++ b/modules/db-liquibase/src/dist/bin/q2
@@ -1,17 +1,78 @@
-#!/bin/sh
+#!/bin/bash
 
-cd `dirname $0`/.. || exit 1
+set -euo pipefail
+cd "$(dirname "$0")/.." || exit 1
 rm -f deploy/shutdown.xml
-exec java -server \
-    -Xmx1G \
-    -Xloggc:log/gc.log \
-    -XX:+PrintGCDetails \
-    -XX:+PrintGCDateStamps \
-    -XX:+UseGCLogFileRotation \
-    -XX:NumberOfGCLogFiles=5 \
-    -XX:GCLogFileSize=2M \
-    -XX:NumberOfGCLogFiles=5 \
-    -Djava.net.preferIPv4Stack=true \
-    -Dcom.sun.management.jmxremote \
-    -jar jposee-@jarname@ --pid-file='jpos.pid' "$@"
 
+INHERITED_JAVA_OPTS="${JAVA_OPTS:-}"
+EXTRA_JAVA_OPTS=()
+EXTRA_OTHER_OPTS=()
+
+PID_FILE="jpos.pid"
+USE_PID=true
+
+for arg in "$@"; do
+  case "$arg" in
+    -D*)
+      EXTRA_JAVA_OPTS+=("$arg")
+      ;;
+    --pid=*)
+      PID_FILE="${arg#--pid=}"
+      ;;
+    --no-pid)
+      USE_PID=false
+      ;;
+    --debug)
+      EXTRA_JAVA_OPTS+=("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
+      ;;
+    *)
+      EXTRA_OTHER_OPTS+=("$arg")
+      ;;
+  esac
+done
+
+if $USE_PID; then
+  if [ -f "$PID_FILE" ] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
+    echo "Process $(cat "$PID_FILE") is running"
+    exit 1
+  fi
+  rm -f "$PID_FILE"
+fi
+
+mkdir -p log
+
+# Locate Java via JAVA_HOME or SDKMAN
+if [ -z "${JAVA_HOME:-}" ]; then
+  SDKMAN_JAVA="$HOME/.sdkman/candidates/java/current"
+  if [ -d "$SDKMAN_JAVA" ]; then
+    export JAVA_HOME="$SDKMAN_JAVA"
+  fi
+fi
+
+# Base JVM invocation. Order matters: every JVM flag (-D, -X, --add-*,
+# agent flags from --debug, INHERITED_JAVA_OPTS from the env var) MUST
+# land before -jar @jarname@. Anything after -jar is treated as a
+# program argument by Java and triggers "Unrecognized option".
+JAVA_CMD="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+
+ENV_JAVA_OPTS=( ${INHERITED_JAVA_OPTS} )
+
+CMD=(
+  "$JAVA_CMD" -server
+  -Xmx4G
+  --enable-native-access=ALL-UNNAMED
+  --sun-misc-unsafe-memory-access=allow
+  -Xlog:gc:log/gc.log
+)
+# JVM flags: in-script defaults first, then env-supplied, then CLI -D.
+CMD+=( ${ENV_JAVA_OPTS[@]+"${ENV_JAVA_OPTS[@]}"} )
+CMD+=( ${EXTRA_JAVA_OPTS[@]+"${EXTRA_JAVA_OPTS[@]}"} )
+# Now the jar selector itself.
+CMD+=( -jar @jarname@ )
+# Program args — these go to Q2's main, not the JVM.
+if $USE_PID; then
+  CMD+=( --pid="$PID_FILE" )
+fi
+CMD+=( ${EXTRA_OTHER_OPTS[@]+"${EXTRA_OTHER_OPTS[@]}"} )
+
+exec "${CMD[@]}"

--- a/modules/http-client/src/dist/bin/q2
+++ b/modules/http-client/src/dist/bin/q2
@@ -1,19 +1,78 @@
-#!/bin/sh
+#!/bin/bash
 
-cd $(dirname $0)/.. || exit 1
+set -euo pipefail
+cd "$(dirname "$0")/.." || exit 1
 rm -f deploy/shutdown.xml
 
-if [ -f jpos.pid ] && ps -p $(cat jpos.pid) > /dev/null 2>&1
-then
-   echo "Process $(cat jpos.pid) is running"
-else
-  rm -f jpos.pid
-  exec java -server \
-    --add-opens java.base/java.lang=ALL-UNNAMED \
-    -XX:+IgnoreUnrecognizedVMOptions \
-    -Xmx1G \
-    -Xlog:gc:log/gc.log \
-    -Dcom.sun.management.jmxremote=true \
-    -jar jposee-@jarname@  --pid="jpos.pid" "$@"
+INHERITED_JAVA_OPTS="${JAVA_OPTS:-}"
+EXTRA_JAVA_OPTS=()
+EXTRA_OTHER_OPTS=()
+
+PID_FILE="jpos.pid"
+USE_PID=true
+
+for arg in "$@"; do
+  case "$arg" in
+    -D*)
+      EXTRA_JAVA_OPTS+=("$arg")
+      ;;
+    --pid=*)
+      PID_FILE="${arg#--pid=}"
+      ;;
+    --no-pid)
+      USE_PID=false
+      ;;
+    --debug)
+      EXTRA_JAVA_OPTS+=("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
+      ;;
+    *)
+      EXTRA_OTHER_OPTS+=("$arg")
+      ;;
+  esac
+done
+
+if $USE_PID; then
+  if [ -f "$PID_FILE" ] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
+    echo "Process $(cat "$PID_FILE") is running"
+    exit 1
+  fi
+  rm -f "$PID_FILE"
 fi
 
+mkdir -p log
+
+# Locate Java via JAVA_HOME or SDKMAN
+if [ -z "${JAVA_HOME:-}" ]; then
+  SDKMAN_JAVA="$HOME/.sdkman/candidates/java/current"
+  if [ -d "$SDKMAN_JAVA" ]; then
+    export JAVA_HOME="$SDKMAN_JAVA"
+  fi
+fi
+
+# Base JVM invocation. Order matters: every JVM flag (-D, -X, --add-*,
+# agent flags from --debug, INHERITED_JAVA_OPTS from the env var) MUST
+# land before -jar @jarname@. Anything after -jar is treated as a
+# program argument by Java and triggers "Unrecognized option".
+JAVA_CMD="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+
+ENV_JAVA_OPTS=( ${INHERITED_JAVA_OPTS} )
+
+CMD=(
+  "$JAVA_CMD" -server
+  -Xmx4G
+  --enable-native-access=ALL-UNNAMED
+  --sun-misc-unsafe-memory-access=allow
+  -Xlog:gc:log/gc.log
+)
+# JVM flags: in-script defaults first, then env-supplied, then CLI -D.
+CMD+=( ${ENV_JAVA_OPTS[@]+"${ENV_JAVA_OPTS[@]}"} )
+CMD+=( ${EXTRA_JAVA_OPTS[@]+"${EXTRA_JAVA_OPTS[@]}"} )
+# Now the jar selector itself.
+CMD+=( -jar @jarname@ )
+# Program args — these go to Q2's main, not the JVM.
+if $USE_PID; then
+  CMD+=( --pid="$PID_FILE" )
+fi
+CMD+=( ${EXTRA_OTHER_OPTS[@]+"${EXTRA_OTHER_OPTS[@]}"} )
+
+exec "${CMD[@]}"

--- a/modules/jetty/src/dist/bin/q2
+++ b/modules/jetty/src/dist/bin/q2
@@ -1,37 +1,78 @@
 #!/bin/bash
 
+set -euo pipefail
 cd "$(dirname "$0")/.." || exit 1
 rm -f deploy/shutdown.xml
 
-# Initialize arrays for JAVA_OPTS and OTHER_OPTS.
-JAVA_OPTS=()
-OTHER_OPTS=()
-PID_FILE="jpos.pid"  # Default value
+INHERITED_JAVA_OPTS="${JAVA_OPTS:-}"
+EXTRA_JAVA_OPTS=()
+EXTRA_OTHER_OPTS=()
+
+PID_FILE="jpos.pid"
+USE_PID=true
 
 for arg in "$@"; do
-  case $arg in
+  case "$arg" in
     -D*)
-      JAVA_OPTS+=("$arg")
+      EXTRA_JAVA_OPTS+=("$arg")
       ;;
     --pid=*)
       PID_FILE="${arg#--pid=}"
       ;;
+    --no-pid)
+      USE_PID=false
+      ;;
+    --debug)
+      EXTRA_JAVA_OPTS+=("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
+      ;;
     *)
-      OTHER_OPTS+=("$arg")
+      EXTRA_OTHER_OPTS+=("$arg")
       ;;
   esac
 done
 
-# Check if the process defined by the PID file is running
-if [ -f "$PID_FILE" ] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
-   echo "Process $(cat "$PID_FILE") is running"
-else
+if $USE_PID; then
+  if [ -f "$PID_FILE" ] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
+    echo "Process $(cat "$PID_FILE") is running"
+    exit 1
+  fi
   rm -f "$PID_FILE"
-
-  mkdir -p log
-  exec java -server \
-    -Xmx4G \
-    --enable-native-access=ALL-UNNAMED \
-    -Xlog:gc:log/gc.log \
-    "${JAVA_OPTS[@]}" -jar @jarname@ --pid="$PID_FILE" "${OTHER_OPTS[@]}"
 fi
+
+mkdir -p log
+
+# Locate Java via JAVA_HOME or SDKMAN
+if [ -z "${JAVA_HOME:-}" ]; then
+  SDKMAN_JAVA="$HOME/.sdkman/candidates/java/current"
+  if [ -d "$SDKMAN_JAVA" ]; then
+    export JAVA_HOME="$SDKMAN_JAVA"
+  fi
+fi
+
+# Base JVM invocation. Order matters: every JVM flag (-D, -X, --add-*,
+# agent flags from --debug, INHERITED_JAVA_OPTS from the env var) MUST
+# land before -jar @jarname@. Anything after -jar is treated as a
+# program argument by Java and triggers "Unrecognized option".
+JAVA_CMD="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+
+ENV_JAVA_OPTS=( ${INHERITED_JAVA_OPTS} )
+
+CMD=(
+  "$JAVA_CMD" -server
+  -Xmx4G
+  --enable-native-access=ALL-UNNAMED
+  --sun-misc-unsafe-memory-access=allow
+  -Xlog:gc:log/gc.log
+)
+# JVM flags: in-script defaults first, then env-supplied, then CLI -D.
+CMD+=( ${ENV_JAVA_OPTS[@]+"${ENV_JAVA_OPTS[@]}"} )
+CMD+=( ${EXTRA_JAVA_OPTS[@]+"${EXTRA_JAVA_OPTS[@]}"} )
+# Now the jar selector itself.
+CMD+=( -jar @jarname@ )
+# Program args — these go to Q2's main, not the JVM.
+if $USE_PID; then
+  CMD+=( --pid="$PID_FILE" )
+fi
+CMD+=( ${EXTRA_OTHER_OPTS[@]+"${EXTRA_OTHER_OPTS[@]}"} )
+
+exec "${CMD[@]}"

--- a/modules/qrest/src/dist/bin/q2
+++ b/modules/qrest/src/dist/bin/q2
@@ -1,9 +1,78 @@
-#!/bin/sh
+#!/bin/bash
 
-cd `dirname $0`/.. || exit 1
+set -euo pipefail
+cd "$(dirname "$0")/.." || exit 1
 rm -f deploy/shutdown.xml
-exec java -server \
-    -Djava.net.preferIPv4Stack=true \
-    -Dcom.sun.management.jmxremote \
-    -jar @jarname@ --pid-file='jpos.pid' "$@"
 
+INHERITED_JAVA_OPTS="${JAVA_OPTS:-}"
+EXTRA_JAVA_OPTS=()
+EXTRA_OTHER_OPTS=()
+
+PID_FILE="jpos.pid"
+USE_PID=true
+
+for arg in "$@"; do
+  case "$arg" in
+    -D*)
+      EXTRA_JAVA_OPTS+=("$arg")
+      ;;
+    --pid=*)
+      PID_FILE="${arg#--pid=}"
+      ;;
+    --no-pid)
+      USE_PID=false
+      ;;
+    --debug)
+      EXTRA_JAVA_OPTS+=("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
+      ;;
+    *)
+      EXTRA_OTHER_OPTS+=("$arg")
+      ;;
+  esac
+done
+
+if $USE_PID; then
+  if [ -f "$PID_FILE" ] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
+    echo "Process $(cat "$PID_FILE") is running"
+    exit 1
+  fi
+  rm -f "$PID_FILE"
+fi
+
+mkdir -p log
+
+# Locate Java via JAVA_HOME or SDKMAN
+if [ -z "${JAVA_HOME:-}" ]; then
+  SDKMAN_JAVA="$HOME/.sdkman/candidates/java/current"
+  if [ -d "$SDKMAN_JAVA" ]; then
+    export JAVA_HOME="$SDKMAN_JAVA"
+  fi
+fi
+
+# Base JVM invocation. Order matters: every JVM flag (-D, -X, --add-*,
+# agent flags from --debug, INHERITED_JAVA_OPTS from the env var) MUST
+# land before -jar @jarname@. Anything after -jar is treated as a
+# program argument by Java and triggers "Unrecognized option".
+JAVA_CMD="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+
+ENV_JAVA_OPTS=( ${INHERITED_JAVA_OPTS} )
+
+CMD=(
+  "$JAVA_CMD" -server
+  -Xmx4G
+  --enable-native-access=ALL-UNNAMED
+  --sun-misc-unsafe-memory-access=allow
+  -Xlog:gc:log/gc.log
+)
+# JVM flags: in-script defaults first, then env-supplied, then CLI -D.
+CMD+=( ${ENV_JAVA_OPTS[@]+"${ENV_JAVA_OPTS[@]}"} )
+CMD+=( ${EXTRA_JAVA_OPTS[@]+"${EXTRA_JAVA_OPTS[@]}"} )
+# Now the jar selector itself.
+CMD+=( -jar @jarname@ )
+# Program args — these go to Q2's main, not the JVM.
+if $USE_PID; then
+  CMD+=( --pid="$PID_FILE" )
+fi
+CMD+=( ${EXTRA_OTHER_OPTS[@]+"${EXTRA_OTHER_OPTS[@]}"} )
+
+exec "${CMD[@]}"

--- a/modules/rest-testbed/src/dist/bin/q2
+++ b/modules/rest-testbed/src/dist/bin/q2
@@ -1,15 +1,78 @@
-#!/bin/sh
+#!/bin/bash
 
-cd `dirname $0`/.. || exit 1
+set -euo pipefail
+cd "$(dirname "$0")/.." || exit 1
 rm -f deploy/shutdown.xml
-java -server \
-    -XX:+IgnoreUnrecognizedVMOptions \
-    -Dappname=jPOSEE-rest-testbed \
-    -Duser.name=admin \
-    -Dcom.sun.management.jmxremote \
-    -Duser.name=admin \
-    -Xloggc:log/gc.log \
-    -Dorg.mortbay.xml.XmlParser.NotValidating=true \
-    -Xmx1G -Xms1G \
-    -jar jposee-@jarname@ "$@"
 
+INHERITED_JAVA_OPTS="${JAVA_OPTS:-}"
+EXTRA_JAVA_OPTS=()
+EXTRA_OTHER_OPTS=()
+
+PID_FILE="jpos.pid"
+USE_PID=true
+
+for arg in "$@"; do
+  case "$arg" in
+    -D*)
+      EXTRA_JAVA_OPTS+=("$arg")
+      ;;
+    --pid=*)
+      PID_FILE="${arg#--pid=}"
+      ;;
+    --no-pid)
+      USE_PID=false
+      ;;
+    --debug)
+      EXTRA_JAVA_OPTS+=("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
+      ;;
+    *)
+      EXTRA_OTHER_OPTS+=("$arg")
+      ;;
+  esac
+done
+
+if $USE_PID; then
+  if [ -f "$PID_FILE" ] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
+    echo "Process $(cat "$PID_FILE") is running"
+    exit 1
+  fi
+  rm -f "$PID_FILE"
+fi
+
+mkdir -p log
+
+# Locate Java via JAVA_HOME or SDKMAN
+if [ -z "${JAVA_HOME:-}" ]; then
+  SDKMAN_JAVA="$HOME/.sdkman/candidates/java/current"
+  if [ -d "$SDKMAN_JAVA" ]; then
+    export JAVA_HOME="$SDKMAN_JAVA"
+  fi
+fi
+
+# Base JVM invocation. Order matters: every JVM flag (-D, -X, --add-*,
+# agent flags from --debug, INHERITED_JAVA_OPTS from the env var) MUST
+# land before -jar @jarname@. Anything after -jar is treated as a
+# program argument by Java and triggers "Unrecognized option".
+JAVA_CMD="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+
+ENV_JAVA_OPTS=( ${INHERITED_JAVA_OPTS} )
+
+CMD=(
+  "$JAVA_CMD" -server
+  -Xmx4G
+  --enable-native-access=ALL-UNNAMED
+  --sun-misc-unsafe-memory-access=allow
+  -Xlog:gc:log/gc.log
+)
+# JVM flags: in-script defaults first, then env-supplied, then CLI -D.
+CMD+=( ${ENV_JAVA_OPTS[@]+"${ENV_JAVA_OPTS[@]}"} )
+CMD+=( ${EXTRA_JAVA_OPTS[@]+"${EXTRA_JAVA_OPTS[@]}"} )
+# Now the jar selector itself.
+CMD+=( -jar @jarname@ )
+# Program args — these go to Q2's main, not the JVM.
+if $USE_PID; then
+  CMD+=( --pid="$PID_FILE" )
+fi
+CMD+=( ${EXTRA_OTHER_OPTS[@]+"${EXTRA_OTHER_OPTS[@]}"} )
+
+exec "${CMD[@]}"

--- a/modules/testbed/src/dist/bin/q2
+++ b/modules/testbed/src/dist/bin/q2
@@ -1,15 +1,78 @@
-#!/bin/sh
+#!/bin/bash
 
-cd `dirname $0`/.. || exit 1
+set -euo pipefail
+cd "$(dirname "$0")/.." || exit 1
 rm -f deploy/shutdown.xml
-java -server \
-    -XX:+IgnoreUnrecognizedVMOptions \
-    -Dappname=jPOSEE-testbed \
-    -Duser.name=admin \
-    -Dcom.sun.management.jmxremote \
-    -Duser.name=admin \
-    -Xloggc:log/gc.log \
-    -Dorg.mortbay.xml.XmlParser.NotValidating=true \
-    -Xmx1G -Xms1G \
-    -jar jposee-@jarname@ "$@"
 
+INHERITED_JAVA_OPTS="${JAVA_OPTS:-}"
+EXTRA_JAVA_OPTS=()
+EXTRA_OTHER_OPTS=()
+
+PID_FILE="jpos.pid"
+USE_PID=true
+
+for arg in "$@"; do
+  case "$arg" in
+    -D*)
+      EXTRA_JAVA_OPTS+=("$arg")
+      ;;
+    --pid=*)
+      PID_FILE="${arg#--pid=}"
+      ;;
+    --no-pid)
+      USE_PID=false
+      ;;
+    --debug)
+      EXTRA_JAVA_OPTS+=("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
+      ;;
+    *)
+      EXTRA_OTHER_OPTS+=("$arg")
+      ;;
+  esac
+done
+
+if $USE_PID; then
+  if [ -f "$PID_FILE" ] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
+    echo "Process $(cat "$PID_FILE") is running"
+    exit 1
+  fi
+  rm -f "$PID_FILE"
+fi
+
+mkdir -p log
+
+# Locate Java via JAVA_HOME or SDKMAN
+if [ -z "${JAVA_HOME:-}" ]; then
+  SDKMAN_JAVA="$HOME/.sdkman/candidates/java/current"
+  if [ -d "$SDKMAN_JAVA" ]; then
+    export JAVA_HOME="$SDKMAN_JAVA"
+  fi
+fi
+
+# Base JVM invocation. Order matters: every JVM flag (-D, -X, --add-*,
+# agent flags from --debug, INHERITED_JAVA_OPTS from the env var) MUST
+# land before -jar @jarname@. Anything after -jar is treated as a
+# program argument by Java and triggers "Unrecognized option".
+JAVA_CMD="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+
+ENV_JAVA_OPTS=( ${INHERITED_JAVA_OPTS} )
+
+CMD=(
+  "$JAVA_CMD" -server
+  -Xmx4G
+  --enable-native-access=ALL-UNNAMED
+  --sun-misc-unsafe-memory-access=allow
+  -Xlog:gc:log/gc.log
+)
+# JVM flags: in-script defaults first, then env-supplied, then CLI -D.
+CMD+=( ${ENV_JAVA_OPTS[@]+"${ENV_JAVA_OPTS[@]}"} )
+CMD+=( ${EXTRA_JAVA_OPTS[@]+"${EXTRA_JAVA_OPTS[@]}"} )
+# Now the jar selector itself.
+CMD+=( -jar @jarname@ )
+# Program args — these go to Q2's main, not the JVM.
+if $USE_PID; then
+  CMD+=( --pid="$PID_FILE" )
+fi
+CMD+=( ${EXTRA_OTHER_OPTS[@]+"${EXTRA_OTHER_OPTS[@]}"} )
+
+exec "${CMD[@]}"


### PR DESCRIPTION
Copies the updated q2 launcher from jPOS commit ebd4eea15.

The launcher now keeps JVM options from JAVA_OPTS and CLI -D arguments before -jar, preserving them as JVM arguments instead of Q2 program arguments.

Verification:
- compared each copied q2 script with jPOS jpos/src/dist/bin/q2
- ran bash -n on all updated q2 scripts