### PR TITLE
Verify release HTTP request reference count in SendResponse

### DIFF
--- a/modules/qrest/src/main/java/org/jpos/qrest/SendResponse.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/SendResponse.java
@@ -56,7 +56,7 @@ public class SendResponse implements AbortParticipant, Configurable {
         Context ctx = (Context) context;
         ChannelHandlerContext ch = ctx.get(SESSION);
         FullHttpRequest request = ctx.get(REQUEST);
-        FullHttpResponse response = getResponse(ctx, request.protocolVersion());
+        FullHttpResponse response = getResponse(ctx, protocolVersion(request));
         sendResponse(ctx, ch, request, response);
     }
 
@@ -65,12 +65,12 @@ public class SendResponse implements AbortParticipant, Configurable {
         Context ctx = (Context) context;
         ChannelHandlerContext ch = ctx.get(SESSION);
         FullHttpRequest request = ctx.get(REQUEST);
-        FullHttpResponse response = getResponse(ctx, request.protocolVersion());
+        FullHttpResponse response = getResponse(ctx, protocolVersion(request));
         sendResponse(ctx, ch, request, response);
     }
 
     private void sendResponse (Context ctx, ChannelHandlerContext ch, FullHttpRequest request, FullHttpResponse response) {
-        boolean keepAlive = HttpUtil.isKeepAlive(request);
+        boolean keepAlive = request != null && HttpUtil.isKeepAlive(request);
         HttpHeaders headers = response.headers();
         try {
             if (keepAlive)
@@ -95,6 +95,10 @@ public class SendResponse implements AbortParticipant, Configurable {
             ReferenceCountUtil.release(request);
         else
             ctx.log("HTTP request already released");
+    }
+
+    private HttpVersion protocolVersion(FullHttpRequest request) {
+        return request != null ? request.protocolVersion() : HttpVersion.HTTP_1_1;
     }
 
     private FullHttpResponse error (HttpResponseStatus rc, HttpVersion version) {

--- a/modules/qrest/src/main/java/org/jpos/qrest/SendResponse.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/SendResponse.java
@@ -84,8 +84,17 @@ public class SendResponse implements AbortParticipant, Configurable {
             if (!keepAlive)
                 cf.addListener(ChannelFutureListener.CLOSE);
         } finally {
-            ReferenceCountUtil.release(request);
+            releaseRequest(ctx, request);
         }
+    }
+
+    private void releaseRequest (Context ctx, FullHttpRequest request) {
+        if (request == null)
+            return;
+        if (ReferenceCountUtil.refCnt(request) > 0)
+            ReferenceCountUtil.release(request);
+        else
+            ctx.log("HTTP request already released");
     }
 
     private FullHttpResponse error (HttpResponseStatus rc, HttpVersion version) {

--- a/modules/qrest/src/test/java/org/jpos/qrest/SendResponseTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/SendResponseTest.java
@@ -1,0 +1,105 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.qrest;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.jpos.transaction.Context;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SendResponseTest {
+    private SendResponse participant;
+    private EmbeddedChannel channel;
+    private ChannelHandlerContext channelHandlerContext;
+
+    @BeforeEach
+    void setUp() {
+        participant = new SendResponse();
+        channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
+            @Override
+            public void handlerAdded(ChannelHandlerContext ctx) {
+                channelHandlerContext = ctx;
+            }
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (channel != null)
+            channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void commitWritesResponseAndReleasesRequest() {
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/balance");
+        request.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+
+        participant.commit(1L, createContext(request));
+
+        assertEquals(0, request.refCnt());
+        FullHttpResponse outbound = channel.readOutbound();
+        assertNotNull(outbound);
+        assertEquals(HttpResponseStatus.OK, outbound.status());
+        assertEquals(String.valueOf(outbound.content().readableBytes()), outbound.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+        outbound.release();
+        assertNull(channel.readOutbound());
+    }
+
+    @Test
+    void commitSkipsReleaseWhenRequestWasAlreadyReleased() {
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/balance");
+        request.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+        assertTrue(request.release());
+
+        assertDoesNotThrow(() -> participant.commit(2L, createContext(request)));
+
+        assertEquals(0, request.refCnt());
+        FullHttpResponse outbound = channel.readOutbound();
+        assertNotNull(outbound);
+        assertEquals(HttpResponseStatus.OK, outbound.status());
+        outbound.release();
+        assertNull(channel.readOutbound());
+    }
+
+    private Context createContext(DefaultFullHttpRequest request) {
+        Context ctx = new Context();
+        ctx.put(Constants.SESSION, channelHandlerContext);
+        ctx.put(Constants.REQUEST, request);
+        ctx.put(Constants.RESPONSE, new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+        return ctx;
+    }
+}
+

--- a/modules/qrest/src/test/java/org/jpos/qrest/SendResponseTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/SendResponseTest.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -94,7 +95,29 @@ class SendResponseTest {
         assertNull(channel.readOutbound());
     }
 
-    private Context createContext(DefaultFullHttpRequest request) {
+    @Test
+    void commitHandlesMissingRequest() {
+        assertDoesNotThrow(() -> participant.commit(3L, createContext(null)));
+
+        FullHttpResponse outbound = channel.readOutbound();
+        assertNotNull(outbound);
+        assertEquals(HttpResponseStatus.OK, outbound.status());
+        outbound.release();
+        assertNull(channel.readOutbound());
+    }
+
+    @Test
+    void abortHandlesMissingRequest() {
+        assertDoesNotThrow(() -> participant.abort(4L, createContext(null)));
+
+        FullHttpResponse outbound = channel.readOutbound();
+        assertNotNull(outbound);
+        assertEquals(HttpResponseStatus.OK, outbound.status());
+        outbound.release();
+        assertNull(channel.readOutbound());
+    }
+
+    private Context createContext(FullHttpRequest request) {
         Context ctx = new Context();
         ctx.put(Constants.SESSION, channelHandlerContext);
         ctx.put(Constants.REQUEST, request);


### PR DESCRIPTION
This pull request improves the safety and test coverage of HTTP request handling in the `SendResponse` class. The main change is the introduction of a safer request release mechanism, along with comprehensive unit tests to verify correct behavior in various scenarios.