### PR TITLE
Compact QRest access event display

### DIFF
--- a/modules/qrest/src/main/java/org/jpos/qrest/evt/QRestAccess.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/evt/QRestAccess.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.jpos.log.AuditLogEvent;
 
 import java.time.Instant;
+import java.util.StringJoiner;
 
 /**
  * Structured access-log entry emitted once per QRest HTTP request.
@@ -43,4 +44,49 @@ public record QRestAccess(
     String queue,
     Long requestBytes,
     Long responseBytes
-) implements AuditLogEvent { }
+) implements AuditLogEvent {
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder()
+          .append(display(method))
+          .append(' ')
+          .append(display(path));
+        if (status != null)
+            sb.append(' ').append(status);
+        if (elapsed != null)
+            sb.append(' ').append(elapsed).append("ms");
+
+        StringJoiner details = new StringJoiner(" ");
+        add(details, "remote", normalizedRemote(remote));
+        add(details, "queue", queue);
+        add(details, "in", bytes(requestBytes));
+        add(details, "out", bytes(responseBytes));
+        String detailString = details.toString();
+        if (!detailString.isEmpty())
+            sb.append(" [").append(detailString).append(']');
+        return sb.toString();
+    }
+
+    private static void add(StringJoiner joiner, String name, String value) {
+        if (value != null && !value.isBlank())
+            joiner.add(name + '=' + value);
+    }
+
+    private static String display(String value) {
+        return value != null && !value.isBlank() ? value : "-";
+    }
+
+    private static String bytes(Long value) {
+        return value != null ? value + "B" : null;
+    }
+
+    private static String normalizedRemote(String value) {
+        if (value == null)
+            return null;
+        return switch (value) {
+            case "0:0:0:0:0:0:0:0" -> "::";
+            case "0:0:0:0:0:0:0:1" -> "::1";
+            default -> value;
+        };
+    }
+}

--- a/modules/qrest/src/test/java/org/jpos/qrest/evt/QRestAccessTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/evt/QRestAccessTest.java
@@ -118,4 +118,33 @@ class QRestAccessTest {
         assertFalse(json.contains("body"), "QRestAccess must not carry a body field");
         assertNotNull(json);
     }
+
+    @Test
+    void toStringUsesCompactAccessLogFormat() {
+        QRestAccess evt = new QRestAccess(
+          Instant.parse("2026-05-07T12:00:00Z"),
+          "GET",
+          "/api/logs/histogram",
+          200,
+          19L,
+          "0:0:0:0:0:0:0:1",
+          "TXNMGR.WEB",
+          0L,
+          1801L
+        );
+
+        assertEquals(
+          "GET /api/logs/histogram 200 19ms [remote=::1 queue=TXNMGR.WEB in=0B out=1801B]",
+          evt.toString()
+        );
+    }
+
+    @Test
+    void toStringOmitsMissingDetails() {
+        QRestAccess evt = new QRestAccess(
+          null, "GET", "/health", null, null, null, null, null, null
+        );
+
+        assertEquals("GET /health", evt.toString());
+    }
 }


### PR DESCRIPTION
## Summary
- make QRestAccess.toString() use compact access-log style output
- omit LogEvent-owned metadata such as event kind and timestamp from the display string
- include secondary QRest fields in bracketed key/value details

Example:
```
GET /api/logs/histogram 200 19ms [remote=::1 queue=TXNMGR.WEB in=0B out=1801B]
```

## Tests
- ./gradlew :modules:qrest:test