### PR TITLE
Update the GLSession query in the getBalance operation

### DIFF
--- a/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
+++ b/modules/minigl/src/main/java/org/jpos/gl/GLSession.java
@@ -1567,7 +1567,7 @@ public class GLSession {
         }
         where(qs, "(entry.transaction = txn.id and txn.journal = :journal)\n");
         if (date != null) {
-            where(qs, "txn.\"postDate\" < :date");
+            where(qs, "txn.postDate < :date");
         }
         where(qs, "entry.layer in");
         qs.append("  (");

--- a/modules/minigl/src/test/java/org/jpos/gl/TestBase.java
+++ b/modules/minigl/src/test/java/org/jpos/gl/TestBase.java
@@ -104,7 +104,7 @@ public abstract class TestBase {
         if (!cfgDir.exists())
             cfgDir.mkdirs();
         Properties props = new Properties();
-        props.setProperty("hibernate.globally_quoted_identifiers", "true");
+        props.setProperty("hibernate.globally_quoted_identifiers", "false");
         props.setProperty("hibernate.connection.provider_class", "org.hibernate.agroal.internal.AgroalConnectionProvider");
         props.setProperty("hibernate.connection.username", System.getProperty("db.username"));
         props.setProperty("hibernate.connection.password", System.getProperty("db.password"));


### PR DESCRIPTION
Changed the query in `GLSession.java` to use `txn.postDate` instead of the previously quoted `txn."postDate"`, ensuring consistency with unquoted identifier usage