### PR TITLE
fix: upgrade Groovy for Java 26 classfiles

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ xmlBind = "4.0.5"
 javaxCache = '1.1.1'
 ehCache = '3.12.0'
 jetty = '12.1.8'
-groovy = '3.0.25'
+groovy = '4.0.32'
 kafka = '4.2.0'
 awssdk = '2.44.0'
 jakartaWsRs = '4.0.0'
@@ -78,9 +78,9 @@ jetty-xml     = { module = "org.eclipse.jetty:jetty-xml",     version.ref = "jet
 jetty-rewrite = { module = "org.eclipse.jetty:jetty-rewrite", version.ref = "jetty" }
 jetty-deploy  = { module = "org.eclipse.jetty:jetty-deploy",  version.ref = "jetty" }
 jetty-ee10-webapp = { module = "org.eclipse.jetty.ee10:jetty-ee10-webapp", version.ref = "jetty" }
-groovy = { module = 'org.codehaus.groovy:groovy', version.ref = 'groovy' }
-groovy_sh = { module = 'org.codehaus.groovy:groovy-groovysh', version.ref = 'groovy' }
-groovy_sql = { module = 'org.codehaus.groovy:groovy-sql', version.ref = 'groovy' }
+groovy = { module = 'org.apache.groovy:groovy', version.ref = 'groovy' }
+groovy_sh = { module = 'org.apache.groovy:groovy-groovysh', version.ref = 'groovy' }
+groovy_sql = { module = 'org.apache.groovy:groovy-sql', version.ref = 'groovy' }
 kafka_clients = { module = 'org.apache.kafka:kafka-clients', version.ref = 'kafka' }
 kafka_streams = { module = 'org.apache.kafka:kafka-streams', version.ref = 'kafka' }
 aws_paymentcryptography = { module = 'software.amazon.awssdk:paymentcryptography', version.ref = 'awssdk' }

--- a/modules/groovy/build.gradle
+++ b/modules/groovy/build.gradle
@@ -6,6 +6,9 @@ dependencies {
     api libs.groovy.sh
     api libs.groovy.sql
 
+    testImplementation testlibs.bundles.junit
+    testRuntimeOnly testlibs.bundles.junit.platform
+
     // implementation libraries.jline
     // api group: 'org.fusesource.jansi', name: 'jansi', version: '1.11'
     // api libraries.groovySql

--- a/modules/groovy/src/main/java/org/jpos/q2/cli/GROOVY.java
+++ b/modules/groovy/src/main/java/org/jpos/q2/cli/GROOVY.java
@@ -20,7 +20,7 @@ package org.jpos.q2.cli;
 
 
 import groovy.lang.Binding;
-import org.codehaus.groovy.tools.shell.Groovysh;
+import org.apache.groovy.groovysh.Groovysh;
 import org.codehaus.groovy.tools.shell.IO;
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Terminal;

--- a/modules/groovy/src/test/java/org/jpos/groovy/GroovySetupTest.java
+++ b/modules/groovy/src/test/java/org/jpos/groovy/GroovySetupTest.java
@@ -1,0 +1,37 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.groovy;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class GroovySetupTest {
+    @Test
+    void runsDefaultGroovySetupScript() {
+        URL script = GroovySetupTest.class.getClassLoader()
+          .getResource("org/jpos/groovy/JPOSGroovyDefaults.groovy");
+
+        assertNotNull(script, "JPOSGroovyDefaults.groovy must be available on the classpath");
+        assertDoesNotThrow(() -> GroovySetup.runScriptOnce(script));
+    }
+}


### PR DESCRIPTION
Upgrades the jPOS-EE Groovy module from Groovy 3.0.25 to Groovy 4.0.32 so runtime Groovy compilation can handle Java 26 classfiles.

This reproduces and guards against the observed failure:

```text
BUG! exception in phase semantic analysis ... Unsupported class file major version 70
```

Changes:

- switch Groovy dependencies to `org.apache.groovy` 4.0.32
- update the Groovy shell import for Groovy 4
- add a regression test that runs `JPOSGroovyDefaults.groovy` through `GroovySetup.runScriptOnce(...)`
- add JUnit test dependencies to the Groovy module

Verification:

- `./gradlew :modules:groovy:test`
