### PR TITLE
feat(simulator): add SQL execution support with MySQL and PostgreSQL

### DIFF
--- a/doc/build.gradle
+++ b/doc/build.gradle
@@ -4,8 +4,10 @@ apply plugin: 'idea'
 import org.jpos.buildtools.docs.DocbookPdf
 import org.jpos.buildtools.docs.DocbookHtml
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 task copySources(type: Sync) {
     from "${projectDir}/src/asciidoc"

--- a/doc/buildSrc/build.gradle
+++ b/doc/buildSrc/build.gradle
@@ -1,18 +1,20 @@
 apply plugin: 'groovy'
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 repositories {
     mavenCentral()
-    maven { url 'http://repository.sonatype.org/content/groups/public' }
+    maven { url 'https://repository.sonatype.org/content/groups/public' }
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 
 dependencies {
-    compile localGroovy()
-    compile 'xerces:xercesImpl:2.11.0',
+    implementation localGroovy()
+    implementation 'xerces:xercesImpl:2.11.0',
             'xml-resolver:xml-resolver:1.2',
             'saxon:saxon:6.5.3',
             'org.apache.xmlgraphics:fop:1.1',

--- a/doc/src/asciidoc/module_client_simulator.adoc
+++ b/doc/src/asciidoc/module_client_simulator.adoc
@@ -249,3 +249,423 @@ At the end, you get a ticket with the test results.
 </log>
 --------------------------------------------------------
 
+==== SQL Execution Support
+
+The client simulator supports optional SQL execution before and after test cases,
+enabling database state verification and cleanup.
+
+[source,xml]
+-------------------------------------------------
+<test file="mytest" name="Test with SQL">
+  <pre-sql>
+    DELETE FROM transactions WHERE trace_id = '000001';
+  </pre-sql>
+  <post-sql>
+    INSERT INTO audit_log (test_name, status) VALUES ('mytest', 'passed');
+  </post-sql>
+</test>
+-------------------------------------------------
+
+The `pre-sql` element contains SQL to execute before the request is sent,
+and `post-sql` contains SQL to execute after the response is received.
+
+===== When to Use SQL Execution
+
+SQL execution is useful for:
+
+* **Setting up test prerequisites** - Ensure required data exists in the database
+* **Partial approval testing** - Set account balances to trigger specific responses
+* **Insufficient balance declines** - Verify decline logic when balance is low
+* **Transaction limits** - Configure daily limits, credit limits for testing
+* **State verification** - Record test outcomes in an audit table
+* **Data cleanup** - Remove test data before or after test runs
+* **Foreign key setup** - Create related records needed for transactions
+
+**Example: Partial Approval Test**
+
+[source,xml]
+-------------------------------------------------
+<test file="partial-auth" name="Partial Approval - Low Balance">
+  <pre-sql>
+    UPDATE accounts SET balance = 50.00 WHERE account_id = '123456';
+  </pre-sql>
+  <post-sql>
+    INSERT INTO test_results (test_name, response_code, timestamp)
+    VALUES ('partial-auth', '14', NOW());
+  </post-sql>
+</test>
+-------------------------------------------------
+
+**Example: Insufficient Balance Decline**
+
+[source,xml]
+-------------------------------------------------
+<test file="decline-low-balance" name="Decline - Insufficient Balance">
+  <pre-sql>
+    UPDATE accounts SET available_balance = 10.00,
+                        ledger_balance = 10.00
+    WHERE card_number = '4111111111111111';
+  </pre-sql>
+</test>
+-------------------------------------------------
+
+**Example: Credit Limit Testing**
+
+[source,xml]
+-------------------------------------------------
+<test file="over-limit" name="Decline - Over Credit Limit">
+  <pre-sql>
+    UPDATE credit_accounts SET current_balance = 9500.00,
+                               credit_limit = 10000.00
+    WHERE account_id = 'CREDIT001';
+  </pre-sql>
+</test>
+-------------------------------------------------
+
+**Example: Daily Limit Exhaustion**
+
+[source,xml]
+-------------------------------------------------
+<test file="daily-limit-exceeded" name="Decline - Daily Limit">
+  <pre-sql>
+    INSERT INTO daily_transactions (card_id, amount, date, count)
+    VALUES ('4111111111111111', 9500.00, CURRENT_DATE, 15)
+    ON CONFLICT DO NOTHING;
+  </pre-sql>
+</test>
+-------------------------------------------------
+
+**Example: Audit Logging**
+
+[source,xml]
+-------------------------------------------------
+<test file="purchase" name="Purchase Test with Audit">
+  <pre-sql>
+    DELETE FROM pending_transactions WHERE trace = '000001';
+  </pre-sql>
+  <post-sql>
+    UPDATE audit_log SET status = 'completed',
+                        response_time = 150
+    WHERE test_name = 'Purchase Test'
+    AND timestamp > NOW() - INTERVAL '1 minute';
+  </post-sql>
+</test>
+-------------------------------------------------
+
+===== Resetting State for Subsequent Tests
+
+The `post-sql` element can be used to reset database state after a test,
+preparing for the next test in the suite. This is useful when tests depend
+on known starting conditions.
+
+**Example: Reset Balance After Test**
+
+[source,xml]
+-------------------------------------------------
+<test file="low-balance-decline" name="Decline - Low Balance">
+  <pre-sql>
+    UPDATE accounts SET balance = 5.00 WHERE account_id = '001';
+  </pre-sql>
+  <post-sql>
+    UPDATE accounts SET balance = 1000.00 WHERE account_id = '001';
+  </post-sql>
+</test>
+-------------------------------------------------
+
+**Example: Chain Tests with State Setup**
+
+In a test suite where multiple tests operate on the same account, use
+`pre-sql` to set up the required state and `post-sql` to restore it:
+
+[source,xml]
+-------------------------------------------------
+<!-- Test 1: Set low balance -->
+<test file="low-balance-test" name="Test Low Balance">
+  <pre-sql>
+    UPDATE accounts SET balance = 5.00 WHERE account_id = '001';
+  </pre-sql>
+</test>
+
+<!-- Test 2: Restore balance for next test -->
+<test file="normal-balance-test" name="Test Normal Balance" continue="yes">
+  <post-sql>
+    UPDATE accounts SET balance = 1000.00 WHERE account_id = '001';
+  </post-sql>
+</test>
+-------------------------------------------------
+
+[NOTE]
+======
+When tests run in sequence, ensure the `post-sql` of one test sets up
+the correct initial state for the next test. Use the `continue="yes"`
+attribute to allow the suite to continue even if one test fails due to
+SQL issues.
+======
+
+===== Execution Order
+
+===== init Script Scope
+
+The `init` script can appear in two locations with different scoping:
+
+**Suite-level `init`** (inside `<test-suite>`):
+
+[source,xml]
+-------------------------------------------------
+<test-suite>
+  <init>
+    // Suite-level init runs once at startup - variables and methods
+    // persist for ALL tests in the suite
+
+    import org.jpos.iso.ISODate;
+    import org.jpos.iso.ISOUtil;
+    import org.jpos.space.*;
+    import java.util.Date;
+
+    // State variables shared across tests
+    String STAN;
+    String RRN;
+    String DE_39;
+
+    // Helper methods - available to all tests
+    String get_stan() {
+        return ISOUtil.zeropad(
+            Long.toString(System.currentTimeMillis() % 1000000L), 6);
+    }
+
+    String get_rrn() {
+        return ISODate.formatDate(new Date(), "MMddHH") + get_stan();
+    }
+
+    // Reset function to clear state between tests
+    reset_vars() {
+        STAN = RRN = DE_39 = null;
+    }
+  </init>
+
+  <test file="echo" count="10" />
+  <test file="auth" />
+</test-suite>
+-------------------------------------------------
+
+**Test-level `init`** (inside individual `<test>`):
+
+[source,xml]
+-------------------------------------------------
+<test file="special-test" name="Special Test">
+  <init>
+    // Runs before this specific test's request
+    String trace = String.valueOf(System.currentTimeMillis() % 1000000);
+  </init>
+</test>
+-------------------------------------------------
+
+[NOTE]
+======
+**Variable Scope Behavior:**
+
+* A single shared BeanShell interpreter is used throughout the test suite
+* Suite-level `init` runs once at startup; variables and methods persist for ALL tests
+* Test-level `init` creates *local* variables that shadow outer variables
+  for the duration of that script only
+* Suite-level init typically defines:
+  ** Constants (String ACQ_ID = "12345678901")
+  ** Helper methods (String get_stan() { ... })
+  ** State variables to link tests (String STAN, RRN)
+  ** Reset/cleanup functions (reset_vars() { ... })
+
+To avoid confusion, avoid shadowing suite-level variables with the same name
+in test-level init.
+======
+
+**Example: Variable Scoping**
+
+[source,xml]
+-------------------------------------------------
+<test-suite>
+  <init>
+    // Runs once - variable persists throughout suite
+    String variableA = "100";
+  </init>
+
+  <test file="test1" name="Test 1">
+    <init>
+      // Creates LOCAL variableA="200", shadows suite-level
+      // After this script ends, local variable is gone
+      String variableA = "200";
+    </init>
+  </test>
+
+  <test file="test2" name="Test 2">
+    <init>
+      // Creates LOCAL variableA="300"
+      String variableA = "300";
+    </init>
+  </test>
+
+  <test file="test3" name="Test 3">
+    <!-- No init - uses suite-level variableA="100" -->
+  </test>
+</test-suite>
+-------------------------------------------------
+
+Result: Test3 sees `variableA = "100"` (the suite-level value).
+
+If test3 used `variableA = "500"` (without `String`), it would modify the
+suite-level variable to "500", affecting all subsequent tests.
+======
+
+The execution order for a test case is:
+
+. `init` - BeanShell script run before field evaluation
+. `pre-sql` - SQL executed before the request is sent
+. Request/Response - ISO message sent and response received
+. `post` - BeanShell script executed after response, can modify or verify response
+. `post-sql` - SQL executed after the response processing completes
+
+[source,xml]
+-------------------------------------------------
+<test file="mypackage" name="Test with All SQL">
+  <init>
+    // Runs first - can set variables for use in scripts
+    String expectedAmount = "100.00";
+  </init>
+  <pre-sql>
+    -- Runs second - set up test data
+    UPDATE accounts SET balance = 50.00 WHERE id = '001';
+  </pre-sql>
+  <post>
+    // Runs after response is received - can verify or modify response
+    // If this script returns false, the test fails
+    System.out.println("Response code: " + response.getString(39));
+  </post>
+  <post-sql>
+    -- Runs last - record result or reset state
+    INSERT INTO test_log (name, result) VALUES ('Test with All SQL', 'OK');
+  </post-sql>
+</test>
+-------------------------------------------------
+
+[NOTE]
+======
+The `init` block runs before any field scripts are evaluated, so variables
+defined there can be used in field value scripts (using `!` or `#` syntax).
+
+The `post` script can return `true` or `false`. If it returns `false`,
+the test case will be marked as FAILED regardless of whether the response
+fields matched. The `testcase` and `response` variables are available in
+the `post` script context.
+======
+
+===== SQL Logging
+
+When SQL is executed, the results are logged:
+
+* `SELECT` queries: Log each row with column names and values
+* `INSERT/UPDATE/DELETE`: Log affected row count
+* Errors: Log the exception with the failed SQL statement
+
+[source,xml]
+-------------------------------------------------
+<pre-sql>
+  SELECT id, name, balance FROM accounts WHERE customer_id = 'C001';
+</pre-sql>
+-------------------------------------------------
+
+Would produce log output such as:
+
+[source]
+-------------------------------------------------
+SQL: Executed: SELECT id, name, balance FROM accounts WHERE customer_id = 'C001'
+SQL: Row: id=1 name=John balance=1500.00
+SQL: Row: id=2 name=Jane balance=2300.00
+-------------------------------------------------
+
+===== Database Configuration
+
+By default, tests use a Testcontainers-based PostgreSQL instance. The database
+can be configured using the `test.clientsim_db_driver` system property:
+
+* `-Dtest.clientsim_db_driver=postgres` (default) - Use PostgreSQL via Testcontainers
+* `-Dtest.clientsim_db_driver=mysql` - Use MySQL via Testcontainers
+* `-Dtest.clientsim_db_driver=local` - Use a pre-configured local database
+
+For local database mode, set these system properties:
+* `db.connection` - JDBC URL
+* `db.username` - Database username
+* `db.password` - Database password
+* `db.driver` - JDBC driver class name
+
+===== Database Dependencies
+
+When using a local database (not Testcontainers), ensure you have the appropriate
+JDBC driver in your classpath. The client-simulator uses Hibernate with an Agroal
+connection pool.
+
+[NOTE]
+======
+Version numbers shown are examples. Use the appropriate version for your
+environment and check the jPOS-EE Bill of Materials (BOM) for managed versions.
+======
+
+[source,groovy]
+-------------------------------------------------
+// PostgreSQL
+implementation 'org.postgresql:postgresql:42.7.11'
+
+// MySQL
+implementation 'com.mysql:mysql-connector-j:9.7.0'
+
+// H2 (for testing)
+implementation 'com.h2database:h2:2.4.240'
+-------------------------------------------------
+
+===== db.properties Configuration
+
+The client simulator reads database configuration from `cfg/db.properties`.
+This file is automatically generated by the test framework when using Testcontainers,
+but for production use, you should create it manually.
+
+[source,properties]
+-------------------------------------------------
+# Connection settings
+hibernate.connection.username=jpos
+hibernate.connection.password=password
+hibernate.connection.url=jdbc:postgresql://localhost:5432/jposee
+hibernate.connection.driver_class=org.postgresql.Driver
+
+# Connection pool provider (Agroal for performance)
+hibernate.connection.provider_class=org.hibernate.agroal.internal.AgroalConnectionProvider
+
+# Connection pool size (tune for your workload)
+hibernate.agroal.minSize=1
+hibernate.agroal.maxSize=8
+-------------------------------------------------
+
+[NOTE]
+======
+The `cfg/db.properties` file must exist in the working directory where
+jPOS is running. If using Testcontainers for testing, this file is
+automatically generated with the appropriate container credentials.
+======
+
+===== Supported Databases
+
+The SQL execution feature has been tested with:
+
+* **PostgreSQL** - Recommended for production use
+* **MySQL** - Supported with some behavior differences (see below)
+* **H2** - Useful for local development and testing
+
+[NOTE]
+======
+**MySQL behavioral differences:**
+
+* Whitespace-only SQL throws a SQLException at the JDBC level
+* Auto-increment syntax differs: use `AUTO_INCREMENT` instead of `SERIAL`
+* Multi-statement execution (semicolon-separated) is not supported in a single call
+
+When writing portable SQL, avoid whitespace-only strings and use individual
+statements instead of semicolon-separated multi-statement SQL.
+======
+

--- a/gradle/testlibs.versions.toml
+++ b/gradle/testlibs.versions.toml
@@ -9,8 +9,9 @@ mockitojupiter = "5.23.0"
 hamcrest = "3.0"
 
 [libraries]
-restAssured = { module = 'io.rest-assured:rest-assured', version.ref='restAssured' } 
+restAssured = { module = 'io.rest-assured:rest-assured', version.ref='restAssured' }
 testcontainers_postgresql = { group = "org.testcontainers", name="postgresql", version.ref = "testcontainers" }
+testcontainers_mysql = { group = "org.testcontainers", name="mysql", version.ref = "testcontainers" }
 testcontainers_kafka = { group = "org.testcontainers", name="kafka", version.ref = "testcontainers" }
 kafkastreams_testutils = { module = "org.apache.kafka:kafka-streams-test-utils", version.ref = "kafkastreams_testutils" }
 

--- a/modules/client-simulator/build.gradle
+++ b/modules/client-simulator/build.gradle
@@ -1,6 +1,27 @@
 description = 'jPOS-EE :: Client Simulator'
 
+// Decide driver at configuration time (default: postgres)
+def dbDriver = (project.findProperty('test.clientsim_db_driver')
+        ?: System.getProperty('test.clientsim_db_driver')
+        ?: 'postgres').toString()
+
+logger.lifecycle("Client Simulator: tests will use DB driver: ${dbDriver}")
+
 dependencies {
     api project(':modules:core')
+    api project(':modules:dbsupport')
+
+    testImplementation project(':modules:db-postgresql')
+    testImplementation project(':modules:db-mysql')
+    testImplementation testlibs.testcontainers.postgresql
+    testImplementation testlibs.testcontainers.mysql
+    testImplementation testlibs.bundles.junit
+    testRuntimeOnly testlibs.bundles.junit.platform
+    testRuntimeOnly 'commons-codec:commons-codec' // required by tar operations in testcontainers
+}
+
+test {
+    maxParallelForks = 1
+    systemProperty "test.clientsim_db_driver", System.getProperty("test.clientsim_db_driver", "postgres")
 }
 

--- a/modules/client-simulator/src/main/java/org/jpos/simulator/SQLFailureException.java
+++ b/modules/client-simulator/src/main/java/org/jpos/simulator/SQLFailureException.java
@@ -20,13 +20,14 @@ package org.jpos.simulator;
 
 /**
  * Exception thrown when SQL execution fails and continue-on-error is disabled.
- * <p>
- * This exception is thrown by {@link TestRunner#executeSQL(String, boolean)} when:
+ *
+ * <p>This exception is thrown by {@link TestRunner#executeSQL(String, boolean)} when:
+ *
  * <ul>
  *   <li>The SQL statement(s) cannot be executed</li>
  *   <li>The {@code continueOnError} parameter is {@code false}</li>
  * </ul>
- * </p>
+ *
  * <p>
  * It carries the failed SQL statement and the underlying cause.
  * </p>

--- a/modules/client-simulator/src/main/java/org/jpos/simulator/SQLFailureException.java
+++ b/modules/client-simulator/src/main/java/org/jpos/simulator/SQLFailureException.java
@@ -1,0 +1,59 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.simulator;
+
+/**
+ * Exception thrown when SQL execution fails and continue-on-error is disabled.
+ * <p>
+ * This exception is thrown by {@link TestRunner#executeSQL(String, boolean)} when:
+ * <ul>
+ *   <li>The SQL statement(s) cannot be executed</li>
+ *   <li>The {@code continueOnError} parameter is {@code false}</li>
+ * </ul>
+ * </p>
+ * <p>
+ * It carries the failed SQL statement and the underlying cause.
+ * </p>
+ *
+ * @see TestRunner#executeSQL(String, boolean)
+ */
+public class SQLFailureException extends RuntimeException {
+    /** The SQL statement that failed */
+    private final String sql;
+
+    /**
+     * Creates a new SQLFailureException with the specified SQL and cause.
+     *
+     * @param sql   The SQL statement that failed
+     * @param cause The underlying cause of the failure
+     */
+    public SQLFailureException (String sql, Throwable cause) {
+        super("SQL execution failed: " + sql, cause);
+        this.sql = sql;
+    }
+
+    /**
+     * Returns the SQL statement that failed.
+     *
+     * @return The failed SQL statement
+     */
+    public String getSql () {
+        return sql;
+    }
+}

--- a/modules/client-simulator/src/main/java/org/jpos/simulator/TestCase.java
+++ b/modules/client-simulator/src/main/java/org/jpos/simulator/TestCase.java
@@ -23,78 +23,342 @@ import org.jpos.iso.ISOUtil;
 import org.jpos.util.Loggeable;
 import java.io.PrintStream;
 
+/**
+ * Represents a single test case within a simulator test suite.
+ * <p>
+ * A TestCase encapsulates all information needed to execute a single ISO-8583
+ * message test, including the request, expected response, evaluation scripts,
+ * and SQL statements to be executed before and/or after the test.
+ * </p>
+ * <p>
+ * The test lifecycle is:
+ * <ol>
+ *   <li>{@link #start()} - marks test start time</li>
+ *   <li>Optional: execute pre-evaluation script via BSH</li>
+ *   <li>Optional: execute preSQL via JDBC</li>
+ *   <li>Send request to MUX</li>
+ *   <li>Receive and validate response</li>
+ *   <li>Optional: execute postSQL via JDBC</li>
+ *   <li>Optional: execute post-evaluation script via BSH</li>
+ *   <li>{@link #end()} - marks test end time</li>
+ * </ol>
+ * </p>
+ *
+ * @author Alejandro P. Revilla
+ * @author <a href="mailto:support@jpos.org">jPOS Support Team</a>
+ * @version $Revision: 1.17 $ $Date: 2006/06/06 00:19:32 $
+ * @see TestRunner
+ * @see <a href="https://www.jpos.org/wiki/ClientSimulator">Client Simulator Documentation</a>
+ */
 public class TestCase implements Loggeable {
+    /** Test completed successfully */
     public static final int OK      = 0;
+
+    /** Test failed - response mismatch or assertion error */
     public static final int FAILURE = 1;
+
+    /** Test timed out - no response received within timeout period */
     public static final int TIMEOUT = 2;
 
+    /** Test case name identifier */
     String name;
+
+    /** Test start timestamp (milliseconds since epoch) */
     long start;
+
+    /** Test end timestamp (milliseconds since epoch) */
     long end;
+
+    /** Request timeout in milliseconds */
     long timeout;
+
+    /** Original request message */
     ISOMsg request;
+
+    /** Request after property substitution and script evaluation */
     ISOMsg expandedRequest;
+
+    /** Actual response received from the MUX */
     ISOMsg response;
+
+    /** Expected response for comparison */
     ISOMsg expectedResponse;
+
+    /** BeanShell script executed before sending request (optional) */
     String preEvaluationScript;
+
+    /** BeanShell script executed after receiving response (optional) */
     String postEvaluationScript;
+
+    /**
+     * SQL statement(s) executed before sending the request.
+     * <p>
+     * Multiple statements can be separated by semicolons (;).
+     * The SQL is executed via JDBC using the Hibernate session.
+     * </p>
+     * <p>
+     * Example usage in test suite XML:
+     * <pre>&lt;pre-sql&gt;INSERT INTO audit_log (test_id) VALUES (123)&lt;/pre-sql&gt;</pre>
+     * </p>
+     *
+     * @see TestRunner#executeSQL(String)
+     */
+    String preSQL;
+
+    /**
+     * SQL statement(s) executed after receiving and validating the response.
+     * <p>
+     * Multiple statements can be separated by semicolons (;).
+     * The SQL is executed via JDBC using the Hibernate session.
+     * </p>
+     * <p>
+     * Example usage in test suite XML:
+     * <pre>&lt;post-sql&gt;UPDATE test_status SET completed=NOW() WHERE test_id=123&lt;/post-sql&gt;</pre>
+     * </p>
+     *
+     * @see TestRunner#executeSQL(String)
+     */
+    String postSQL;
+
+    /**
+     * If true, continue running tests even if SQL execution fails.
+     * <p>
+     * When false (default: true for backward compatibility), a SQL failure
+     * will throw {@link SQLFailureException} and stop test execution.
+     * </p>
+     */
+    private boolean continueOnSqlError;
+
+    /** Result code indicating test outcome */
     int resultCode;
+
+    /** If true, continue executing tests even if this one fails */
     boolean continueOnErrors;
+
+    /** Path to the test case files (used for error reporting) */
     private String testcasePath;
+
+    /** Number of times to repeat this test case */
     private long count;
 
-
+    /**
+     * Creates a new TestCase with the specified name.
+     *
+     * @param name Unique identifier for this test case
+     */
     public TestCase (String name) {
         super();
         this.name = name;
         this.resultCode = -1;
         this.continueOnErrors = false;
+        this.continueOnSqlError = true;
     }
+
+    /**
+     * Sets the original ISO-8583 request message.
+     *
+     * @param request The request message to send
+     */
     public void setRequest (ISOMsg request) {
         this.request = request;
     }
+
+    /**
+     * Sets the actual response received from the MUX.
+     *
+     * @param response The response message received
+     */
     public void setResponse (ISOMsg response) {
         this.response = response;
     }
+
+    /**
+     * Sets the request after property substitution and script evaluation.
+     *
+     * @param expandedRequest The expanded request message
+     */
     public void setExpandedRequest (ISOMsg expandedRequest) {
         this.expandedRequest = expandedRequest;
     }
+
+    /**
+     * Sets the expected response for validation.
+     *
+     * @param expectedResponse The expected response message
+     */
     public void setExpectedResponse (ISOMsg expectedResponse) {
         this.expectedResponse = expectedResponse;
     }
+
+    /**
+     * Returns the test case name.
+     *
+     * @return The test case name
+     */
     public String getName () {
         return name;
     }
+
+    /**
+     * Sets the BeanShell script to execute before sending the request.
+     * <p>
+     * The script has access to variables "testcase" (this TestCase) and "request" (the ISOMsg).
+     * </p>
+     *
+     * @param preEvaluationScript BSH script to execute pre-request
+     */
     public void setPreEvaluationScript (String preEvaluationScript) {
         this.preEvaluationScript = preEvaluationScript;
     }
+
+    /**
+     * Returns the pre-evaluation script.
+     *
+     * @return The BSH script, or null if not set
+     */
     public String getPreEvaluationScript () {
         return preEvaluationScript;
     }
+
+    /**
+     * Sets the BeanShell script to execute after receiving the response.
+     * <p>
+     * The script has access to variables "testcase" (this TestCase) and "response" (the ISOMsg).
+     * If the script returns Boolean.FALSE, the test is marked as failed.
+     * </p>
+     *
+     * @param postEvaluationScript BSH script to execute post-response
+     */
     public void setPostEvaluationScript (String postEvaluationScript) {
         this.postEvaluationScript = postEvaluationScript;
     }
+
+    /**
+     * Returns the post-evaluation script.
+     *
+     * @return The BSH script, or null if not set
+     */
     public String getPostEvaluationScript () {
         return postEvaluationScript;
     }
+
+    /**
+     * Sets the SQL statement(s) to execute before sending the request.
+     * <p>
+     * Multiple statements can be separated by semicolons.
+     * The SQL is executed using the database connection from {@link org.jpos.ee.DB}.
+     * </p>
+     * <p>
+     * Example:
+     * <pre>setPreSQL("INSERT INTO audit_log (test_name) VALUES ('test1')");</pre>
+     * </p>
+     *
+     * @param preSQL SQL statement(s) to execute pre-request, or null for no pre-SQL
+     * @see #getPreSQL()
+     * @see TestRunner#executeSQL(String)
+     */
+    public void setPreSQL (String preSQL) {
+        this.preSQL = preSQL;
+    }
+
+    /**
+     * Returns the SQL statement(s) to execute before the request.
+     *
+     * @return The pre-SQL statement(s), or null if not set
+     * @see #setPreSQL(String)
+     */
+    public String getPreSQL () {
+        return preSQL;
+    }
+
+    /**
+     * Sets the SQL statement(s) to execute after receiving the response.
+     * <p>
+     * Multiple statements can be separated by semicolons.
+     * The SQL is executed using the database connection from {@link org.jpos.ee.DB}.
+     * </p>
+     * <p>
+     * Example:
+     * <pre>setPostSQL("UPDATE test_status SET done=1 WHERE id=123; INSERT INTO results VALUES (456)");</pre>
+     * </p>
+     *
+     * @param postSQL SQL statement(s) to execute post-response, or null for no post-SQL
+     * @see #getPostSQL()
+     * @see TestRunner#executeSQL(String)
+     */
+    public void setPostSQL (String postSQL) {
+        this.postSQL = postSQL;
+    }
+
+    /**
+     * Returns the SQL statement(s) to execute after the response.
+     *
+     * @return The post-SQL statement(s), or null if not set
+     * @see #setPostSQL(String)
+     */
+    public String getPostSQL () {
+        return postSQL;
+    }
+
+    /**
+     * Returns the original request message.
+     *
+     * @return The request ISOMsg, or null if not set
+     */
     public ISOMsg getRequest() {
         return request;
     }
+
+    /**
+     * Returns the expanded request message (after property substitution).
+     *
+     * @return The expanded request ISOMsg, or null if not set
+     */
     public ISOMsg getExpandedRequest() {
         return expandedRequest;
     }
+
+    /**
+     * Returns the actual response received.
+     *
+     * @return The response ISOMsg, or null if not yet received
+     */
     public ISOMsg getResponse() {
         return response;
     }
+
+    /**
+     * Returns the expected response for validation.
+     *
+     * @return The expected response ISOMsg, or null if not set
+     */
     public ISOMsg getExpectedResponse() {
         return expectedResponse;
     }
+
+    /**
+     * Sets the result code for this test case.
+     *
+     * @param resultCode One of: {@link #OK}, {@link #FAILURE}, {@link #TIMEOUT}, or custom code
+     */
     public void setResultCode (int resultCode) {
         this.resultCode = resultCode;
     }
+
+    /**
+     * Returns the result code for this test case.
+     *
+     * @return The result code: {@link #OK}, {@link #FAILURE}, {@link #TIMEOUT}, or custom code
+     */
     public int getResultCode () {
         return resultCode;
     }
+
+    /**
+     * Returns the result code as a human-readable string.
+     *
+     * @return "OK", "FAILURE", "TIMEOUT", or the numeric code as a string
+     */
     public String getResultCodeAsString () {
         switch (resultCode) {
             case OK :
@@ -107,6 +371,17 @@ public class TestCase implements Loggeable {
                 return Integer.toString (resultCode);
         }
     }
+
+    /**
+     * Dumps the test case state to the provided PrintStream in XML format.
+     * <p>
+     * The output includes request, expanded request, expected response,
+     * actual response, pre-SQL, post-SQL, and elapsed time.
+     * </p>
+     *
+     * @param p     The PrintStream to write to
+     * @param indent The indentation string for nested elements
+     */
     public void dump (PrintStream p, String indent) {
         String inner = indent + "  ";
         p.println (indent + "<test-case name='" + name + "'>");
@@ -126,9 +401,28 @@ public class TestCase implements Loggeable {
             response.dump (p, inner + "  ");
             p.println (inner + "</response>");
         }
+        if (preSQL != null) {
+            p.println (inner + "<pre-sql>");
+            p.println (inner + "  " + preSQL);
+            p.println (inner + "</pre-sql>");
+        }
+        if (postSQL != null) {
+            p.println (inner + "<post-sql>");
+            p.println (inner + "  " + postSQL);
+            p.println (inner + "</post-sql>");
+        }
         p.println (inner + "<elapsed>" + elapsed() + "</elapsed>");
         p.println (indent + "</test-case>");
     }
+
+    /**
+     * Returns a single-line string representation of the test case result.
+     * <p>
+     * Format: "test-case-name-here                    [OK] 123ms."
+     * </p>
+     *
+     * @return String representation of test case status
+     */
     public String toString() {
         StringBuffer sb = new StringBuffer(ISOUtil.strpad (name, 50));
         sb.append (" [");
@@ -138,45 +432,149 @@ public class TestCase implements Loggeable {
         sb.append ("ms.");
         return sb.toString();
     }
+
+    /**
+     * Marks the start time of the test case.
+     * <p>
+     * Typically called just before sending the request to the MUX.
+     * </p>
+     *
+     * @see #end()
+     */
     public void start() {
         start = System.currentTimeMillis();
     }
+
+    /**
+     * Marks the end time of the test case.
+     * <p>
+     * Typically called after receiving and processing the response.
+     * </p>
+     *
+     * @see #start()
+     */
     public void end () {
         end = System.currentTimeMillis();
     }
+
+    /**
+     * Calculates the elapsed time in milliseconds.
+     * <p>
+     * If start has been set but end has not, automatically calls {@link #end()}.
+     * </p>
+     *
+     * @return Elapsed time in milliseconds
+     */
     public long elapsed() {
         if (start != 0 && end == 0)
             end();
         return end - start;
     }
+
+    /**
+     * Returns true if the test case completed successfully.
+     *
+     * @return true if result code is {@link #OK}
+     */
     public boolean ok() {
         return resultCode == OK;
     }
+
+    /**
+     * Sets whether to continue running tests if this one fails.
+     *
+     * @param continueOnErrors true to continue on failure, false to stop
+     */
     public void setContinueOnErrors (boolean continueOnErrors) {
         this.continueOnErrors = continueOnErrors;
     }
+
+    /**
+     * Returns whether to continue on errors.
+     *
+     * @return true if continue on failure is enabled
+     */
     public boolean isContinueOnErrors () {
         return continueOnErrors;
     }
+
+    /**
+     * Sets whether to continue running tests if SQL execution fails.
+     * <p>
+     * When false, a SQL failure will throw {@link SQLFailureException} and stop test execution.
+     * Default is true for backward compatibility with existing test configurations.
+     * </p>
+     *
+     * @param continueOnSqlError true to continue on SQL error, false to stop
+     * @see #isContinueOnSqlError()
+     */
+    public void setContinueOnSqlError (boolean continueOnSqlError) {
+        this.continueOnSqlError = continueOnSqlError;
+    }
+
+    /**
+     * Returns whether to continue on SQL errors.
+     *
+     * @return true if continuing on SQL error is enabled
+     */
+    public boolean isContinueOnSqlError () {
+        return continueOnSqlError;
+    }
+
+    /**
+     * Sets the request timeout in milliseconds.
+     *
+     * @param timeout Timeout in milliseconds
+     */
     public void setTimeout (long timeout) {
         this.timeout = timeout;
     }
+
+    /**
+     * Returns the request timeout in milliseconds.
+     *
+     * @return Timeout in milliseconds
+     */
     public long getTimeout () {
         return timeout;
     }
-    public void setFilename(String string) {
 
+    /**
+     * Sets the file path associated with this test case.
+     * <p>
+     * Used for error reporting and logging.
+     * </p>
+     *
+     * @param string The file path to the test case files
+     */
+    public void setFilename(String string) {
         testcasePath  = string;
     }
+
+    /**
+     * Returns the file path associated with this test case.
+     *
+     * @return The file path, or null if not set
+     */
     public String getFilename() {
         return testcasePath;
     }
+
+    /**
+     * Sets the number of times to repeat this test case.
+     *
+     * @param count Number of repetitions (default is 1)
+     */
 	public void setCount(long count) {
 		this.count = count;
 	}
+
+    /**
+     * Returns the repetition count.
+     *
+     * @return Number of times to repeat this test case
+     */
     public long getCount() {
         return count;
     }
-	
 }
-

--- a/modules/client-simulator/src/main/java/org/jpos/simulator/TestCase.java
+++ b/modules/client-simulator/src/main/java/org/jpos/simulator/TestCase.java
@@ -25,24 +25,24 @@ import java.io.PrintStream;
 
 /**
  * Represents a single test case within a simulator test suite.
+ *
  * <p>
  * A TestCase encapsulates all information needed to execute a single ISO-8583
  * message test, including the request, expected response, evaluation scripts,
  * and SQL statements to be executed before and/or after the test.
- * </p>
- * <p>
- * The test lifecycle is:
+ *
+ * <p>The test lifecycle is:
+ *
  * <ol>
- *   <li>{@link #start()} - marks test start time</li>
+ *   <li>{@link #start()} - marks the test start time</li>
  *   <li>Optional: execute pre-evaluation script via BSH</li>
- *   <li>Optional: execute preSQL via JDBC</li>
+ *   <li>Optional: execute pre-SQL via JDBC</li>
  *   <li>Send request to MUX</li>
  *   <li>Receive and validate response</li>
- *   <li>Optional: execute postSQL via JDBC</li>
+ *   <li>Optional: execute post-SQL via JDBC</li>
  *   <li>Optional: execute post-evaluation script via BSH</li>
- *   <li>{@link #end()} - marks test end time</li>
+ *   <li>{@link #end()} - marks the test end time</li>
  * </ol>
- * </p>
  *
  * @author Alejandro P. Revilla
  * @author <a href="mailto:support@jpos.org">jPOS Support Team</a>
@@ -251,7 +251,6 @@ public class TestCase implements Loggeable {
      * <p>
      * Example:
      * <pre>setPreSQL("INSERT INTO audit_log (test_name) VALUES ('test1')");</pre>
-     * </p>
      *
      * @param preSQL SQL statement(s) to execute pre-request, or null for no pre-SQL
      * @see #getPreSQL()
@@ -280,7 +279,6 @@ public class TestCase implements Loggeable {
      * <p>
      * Example:
      * <pre>setPostSQL("UPDATE test_status SET done=1 WHERE id=123; INSERT INTO results VALUES (456)");</pre>
-     * </p>
      *
      * @param postSQL SQL statement(s) to execute post-response, or null for no post-SQL
      * @see #getPostSQL()

--- a/modules/client-simulator/src/main/java/org/jpos/simulator/TestRunner.java
+++ b/modules/client-simulator/src/main/java/org/jpos/simulator/TestRunner.java
@@ -18,400 +18,821 @@
 
 package org.jpos.simulator;
 
+import bsh.BshClassManager;
+import bsh.EvalError;
+import bsh.Interpreter;
+import bsh.UtilEvalError;
 import java.io.File;
-import java.io.IOException;
 import java.io.FileInputStream;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.Statement;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
+import org.hibernate.Session;
+import org.hibernate.jdbc.Work;
+import org.jdom2.Element;
 import org.jpos.core.Environment;
+import org.jpos.ee.DB;
 import org.jpos.iso.*;
 import org.jpos.iso.packager.XMLPackager;
-import org.jpos.util.Logger;
 import org.jpos.util.LogEvent;
-import org.jdom2.Element;
+import org.jpos.util.Logger;
 import org.jpos.util.NameRegistrar;
-import bsh.Interpreter;
-import bsh.BshClassManager;
-import bsh.EvalError;
-import bsh.UtilEvalError;
 import org.xml.sax.SAXException;
 
-public class TestRunner
-    extends org.jpos.q2.QBeanSupport
-    implements Runnable
-{
-    MUX mux;
-    ISOPackager packager;
-    Interpreter bsh;
-    
-    long timeout;
-    private static final String NL = System.getProperty("line.separator");
-    public static final long TIMEOUT = 60000;
-    public TestRunner () {
-        super();
+/**
+ * TestRunner executes a suite of simulator test cases against an ISO-8583 MUX.
+ * <p>
+ * TestRunner is a QBean that loads test case definitions from an XML configuration
+ * and executes them sequentially. Each test case can include:
+ * <ul>
+ *   <li>Pre-evaluation BeanShell scripts (to prepare request data)</li>
+ *   <li>Pre-SQL statements (to perform database operations before the request)</li>
+ *   <li>ISO-8583 request/response exchange via MUX</li>
+ *   <li>Post-SQL statements (to perform database operations after the response)</li>
+ *   <li>Post-evaluation BeanShell scripts (to validate response data)</li>
+ * </ul>
+ * </p>
+ * <p>
+ * Configuration example in a Q2 deploy.xml:
+ * <pre>
+ * &lt;test-runner realm="simulator" class="org.jpos.simulator.TestRunner"&gt;
+ *     &lt;property name="mux" value="mux.selector"/&gt;
+ *     &lt;property name="timeout" value="30000"/&gt;
+ *     &lt;property name="sessions" value="1"/&gt;
+ *     &lt;property name="shutdown" value="true"/&gt;
+ *     &lt;test-suite&gt;
+ *         &lt;path&gt;/opt/simulator/tests/&lt;/path&gt;
+ *         &lt;test name="authorization" file="0200" continue-on-sql-error="no"&gt;
+ *             &lt;init&gt;...optional BSH script...&lt;/init&gt;
+ *             &lt;pre-sql&gt;...optional SQL...&lt;/pre-sql&gt;
+ *             &lt;post&gt;...optional BSH script...&lt;/post&gt;
+ *             &lt;post-sql&gt;...optional SQL...&lt;/post-sql&gt;
+ *         &lt;/test&gt;
+ *     &lt;/test-suite&gt;
+ * &lt;/test-runner&gt;
+ * </pre>
+ * </p>
+ *
+ * @author Alejandro P. Revilla
+ * @author <a href="mailto:support@jpos.org">jPOS Support Team</a>
+ * @version $Revision: 1.17 $ $Date: 2006/06/06 00:19:32 $
+ * @see TestCase
+ * @see <a href="https://www.jpos.org/wiki/ClientSimulator">Client Simulator Documentation</a>
+ */
+public class TestRunner extends org.jpos.q2.QBeanSupport implements Runnable {
+
+  /** MUX used to send/receive ISO-8583 messages */
+  MUX mux;
+
+  /** Packager for parsing test case message files */
+  ISOPackager packager;
+
+  /** BeanShell interpreter for evaluating scripts */
+  Interpreter bsh;
+
+  /** Default timeout for requests without per-test timeout */
+  long timeout;
+
+  /** Newline separator for log output */
+  private static final String NL = System.getProperty("line.separator");
+
+  /** Default request timeout (60 seconds) */
+  public static final long TIMEOUT = 60000;
+
+  /**
+   * Creates a new TestRunner instance.
+   */
+  public TestRunner() {
+    super();
+  }
+
+  /**
+   * Initializes the service by loading the packager configuration.
+   * <p>
+   * The packager class can be specified via the "packager" configuration property.
+   * If not specified, a default XMLPackager is used.
+   * </p>
+   *
+   * @throws ISOException if the packager cannot be instantiated
+   */
+  protected void initService() throws ISOException {
+    String packagerClass = cfg.get("packager", null);
+    timeout = cfg.getLong("timeout", TIMEOUT);
+    if (packagerClass != null) {
+      try {
+        packager = (ISOPackager) Class.forName(packagerClass).newInstance();
+      } catch (
+        InstantiationException
+        | IllegalAccessException
+        | ClassNotFoundException e
+      ) {
+        throw new ISOException("Error instatiating packager", e);
+      }
+    } else {
+      packager = getDefaultPackager();
     }
-    protected void initService() throws ISOException {
-        String packagerClass = cfg.get("packager", null);
-        timeout = cfg.getLong ("timeout", TIMEOUT);
-        if (packagerClass != null) {
-            try {
-                packager = (ISOPackager) Class.forName(packagerClass).newInstance();
-            } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-                throw new ISOException("Error instatiating packager", e);
-            }
-        } else {
-            packager = getDefaultPackager();
-        }
-    }
-    protected void startService() {
-        int sessions = cfg.getInt("sessions", 1);
-        ExecutorService executor = Executors.newCachedThreadPool();
-        for (int i=0; i<sessions; i++)
-            executor.execute(this);
-        executor.shutdown();
-        if (cfg.getBoolean ("shutdown")) {
-            Executors.newSingleThreadExecutor().execute( () -> {
-                try {
-                    if (!executor.awaitTermination(timeout, TimeUnit.MILLISECONDS)) {
-                        log.warn("Runners didn't finish before global timeout");
-                    }
-                } catch (InterruptedException e) {
-                    log.warn("interrupted while awaiting workers termination", e);
-                }
-                getServer().shutdown();
-            });
-        }
-    }
-    public void run () {
+  }
+
+  /**
+   * Starts the service by creating a thread pool and launching runner threads.
+   * <p>
+   * The number of concurrent sessions is controlled by the "sessions" configuration property.
+   * If "shutdown" is true, the Q2 server will be shut down after all tests complete or on timeout.
+   * </p>
+   */
+  protected void startService() {
+    int sessions = cfg.getInt("sessions", 1);
+    ExecutorService executor = Executors.newCachedThreadPool();
+    for (int i = 0; i < sessions; i++) executor.execute(this);
+    executor.shutdown();
+    if (cfg.getBoolean("shutdown")) {
+      Executors.newSingleThreadExecutor().execute(() -> {
         try {
-            Interpreter bsh = initBSH ();
-            mux = (MUX) NameRegistrar.get ("mux." + cfg.get ("mux"));
-            List suite = initSuite (getPersist().getChild ("test-suite"));
-            runSuite (suite, mux, bsh);
-        } catch (NameRegistrar.NotFoundException e) {
-            LogEvent evt = getLog().createError ();
-            evt.addMessage (e);
-            evt.addMessage (NameRegistrar.getInstance());
-            Logger.log (evt);
-        } catch (Throwable t) {
-            getLog().error (t);
+          if (!executor.awaitTermination(timeout, TimeUnit.MILLISECONDS)) {
+            log.warn("Runners didn't finish before global timeout");
+          }
+        } catch (InterruptedException e) {
+          log.warn("interrupted while awaiting workers termination", e);
         }
+        getServer().shutdown();
+      });
     }
-    private void runSuite (List suite, MUX mux, Interpreter bsh)
-        throws ISOException, IOException, EvalError
-    {
-        LogEvent evt = getLog().createLogEvent ("results");
-        LogEvent evt_error = null;
-        Iterator iter = suite.iterator();
-        long start = System.currentTimeMillis();
-        long serverTime = 0;
-        for (int i=1; iter.hasNext(); i++) {
-            evt_error = getLog().createLogEvent("error");
-            TestCase tc = (TestCase) iter.next();
-            for (long repetition = 0; repetition < tc.getCount(); repetition++) {
-                getLog().trace (
-                    "---------------------------[ "
-                  + tc.getName()
-                  + " ]---------------------------" );
+  }
 
-                ISOMsg m = (ISOMsg) tc.getRequest().clone();
-                if (tc.getPreEvaluationScript() != null) {
-                    bsh.set ("testcase", tc);
-                    bsh.set ("request", m);
-                    bsh.eval (tc.getPreEvaluationScript());
-                }
-                tc.setExpandedRequest (applyRequestProps (m, bsh));
-                tc.start();
-                if (tc.getExpectedResponse() != null) {
-                    tc.setResponse(mux.request(m, tc.getTimeout()));
-                    tc.end();
-                    assertResponse(tc, bsh, evt_error);
-                    evt.addMessage(i + ": " + tc.toString());
-                    if (evt_error.getPayLoad().size() != 0) {
-                        evt_error.addMessage("filename", tc.getFilename());
-                        evt.addMessage(NL + evt_error.toString("    "));
-                    }
-                    serverTime += tc.elapsed();
-                    if (!tc.ok() && !tc.isContinueOnErrors())
-                        break;
-                } else {
-                    // response not expected - fire and forget
-                    mux.send(m);
-                    tc.end();
-                    tc.setResultCode(TestCase.OK);
-                    evt.addMessage(i + ": " + tc.toString() + " (response ignored)");
-                }
-            }
-            if (!tc.ok()) {
-                getLog().error (tc);
-                if (!tc.isContinueOnErrors())
-                    break;
-            }
-        }
-        long end = System.currentTimeMillis();
+  /**
+   * Main execution loop - loads test suite and runs all test cases.
+   * <p>
+   * This method is called by each runner thread. It initializes the BeanShell interpreter,
+   * looks up the MUX from the NameRegistrar, loads the test suite, and executes it.
+   * </p>
+   */
+  public void run() {
+    try {
+      Interpreter bsh = initBSH();
+      mux = (MUX) NameRegistrar.get("mux." + cfg.get("mux"));
+      List suite = initSuite(getPersist().getChild("test-suite"));
+      runSuite(suite, mux, bsh);
+    } catch (NameRegistrar.NotFoundException e) {
+      LogEvent evt = getLog().createError();
+      evt.addMessage(e);
+      evt.addMessage(NameRegistrar.getInstance());
+      Logger.log(evt);
+    } catch (Throwable t) {
+      getLog().error(t);
+    }
+  }
 
-        long simulatorTime = end - start - serverTime;
-        long total = end - start;
-
-        evt.addMessage (
-            "elapsed server=" + serverTime
-            + "ms(" + percentage (serverTime, total) + "%)"
-            + ", simulator=" + simulatorTime
-            + "ms(" + percentage (simulatorTime, total) + "%)"
-            + ", total=" + total + "ms, shutdown="
-            + cfg.getBoolean("shutdown")
+ /**
+    * Runs the complete test suite, executing each test case in order.
+    * <p>
+    * For each test case:
+    * <ol>
+    *   <li>Execute pre-evaluation script (if configured)</li>
+     *   <li>Execute pre-SQL (if configured) — catches {@link SQLFailureException}</li>
+    *   <li>Clone and expand the request message</li>
+    *   <li>Send request to MUX and measure elapsed time</li>
+     *   <li>Execute post-SQL (if configured and response was expected) — catches {@link SQLFailureException}</li>
+    *   <li>Validate response and set result code</li>
+    * </ol>
+    * </p>
+    * <p>
+    * When {@code continue-on-sql-error="no"} is set on a test case, SQL execution failures
+    * are caught, logged, and cause the test to fail. If {@code continue="yes"} is also set,
+    * subsequent tests will still run.
+    * </p>
+    *
+    * @param suite List of TestCase objects to execute
+    * @param mux The MUX to use for sending/receiving messages
+    * @param bsh BeanShell interpreter for script evaluation
+    * @throws ISOException if message processing fails
+    * @throws IOException if file operations fail
+    * @throws EvalError if script evaluation fails
+    */
+  private void runSuite(List suite, MUX mux, Interpreter bsh)
+    throws ISOException, IOException, EvalError {
+    LogEvent evt = getLog().createLogEvent("results");
+    LogEvent evt_error = null;
+    Iterator iter = suite.iterator();
+    long start = System.currentTimeMillis();
+    long serverTime = 0;
+    for (int i = 1; iter.hasNext(); i++) {
+      evt_error = getLog().createLogEvent("error");
+      TestCase tc = (TestCase) iter.next();
+      for (long repetition = 0; repetition < tc.getCount(); repetition++) {
+        getLog().trace(
+          "---------------------------[ " +
+            tc.getName() +
+            " ]---------------------------"
         );
-        ISOUtil.sleep (100);     // let the channel do its logging first
-        if (cfg.getBoolean ("shutdown"))
-            evt.addMessage ("waiting for shutdown");
 
-        Logger.log (evt);
-    }
-    private List<TestCase> initSuite (Element suite)
-        throws IOException, ISOException
-    {
-        List<TestCase> l = new ArrayList<>();
-        String prefix = suite.getChildTextTrim ("path");
-        Iterator iter = suite.getChildren ("test").iterator();
-        while (iter.hasNext ()) {
-            Element e = (Element) iter.next ();
-            boolean cont = "yes".equals (e.getAttributeValue ("continue"));
-            String s = e.getAttributeValue ("count");
-            int count = s != null ? Integer.parseInt (s) : 1;
-            String path = e.getAttributeValue ("file");
-            String name = e.getAttributeValue ("name");
-            if (name == null)
-                name = path;
-
-            TestCase tc = new TestCase (name);
-            tc.setCount(count);
-            tc.setContinueOnErrors (cont);
-            tc.setRequest (getMessage (prefix + path + "_s"));
-            tc.setExpectedResponse (getMessage (prefix + path + "_r"));
-            tc.setPreEvaluationScript (e.getChildTextTrim ("init"));
-            tc.setPostEvaluationScript (e.getChildTextTrim ("post"));
-            tc.setFilename(prefix + path);
-
-            String to  = e.getAttributeValue ("timeout");
-            if (to != null)
-                tc.setTimeout (Long.parseLong (to));
-            else
-                tc.setTimeout (timeout);
-            l.add (tc);
-
+        ISOMsg m = (ISOMsg) tc.getRequest().clone();
+        // Execute pre-evaluation script if configured
+        if (tc.getPreEvaluationScript() != null) {
+          bsh.set("testcase", tc);
+          bsh.set("request", m);
+          bsh.eval(tc.getPreEvaluationScript());
         }
-        return l;
-    }
-    private ISOMsg getMessage (String filename)
-        throws IOException, ISOException
-    {
-        File f = new File (filename);
-        ISOMsg m = null;
-        if (f.canRead()) {
-            try (FileInputStream fis = new FileInputStream (f)) {
-                byte[] b  = new byte[fis.available()];
-                fis.read (b);
-                m = new ISOMsg ();
-                m.setPackager (packager);
-                try {
-                    m.unpack(b);
-                } catch (ISOException e) {
-                    throw new ISOException ("Error parsing '" + filename + "'", e);
-                }
+        // Execute pre-SQL if configured (e.g., setup test data)
+        if (tc.getPreSQL() != null) {
+          try {
+            executeSQL(tc.getPreSQL(), tc.isContinueOnSqlError());
+          } catch (SQLFailureException e) {
+            getLog().error(e);
+            tc.setResultCode(TestCase.FAILURE);
+            if (!tc.isContinueOnErrors()) break;
+          }
+        }
+        // Apply property substitutions and expand request
+        tc.setExpandedRequest(applyRequestProps(m, bsh));
+        tc.start();
+        if (tc.getExpectedResponse() != null) {
+          // Send request and wait for response
+          tc.setResponse(mux.request(m, tc.getTimeout()));
+          tc.end();
+          assertResponse(tc, bsh, evt_error);
+          // Execute post-SQL if configured (e.g., record test result)
+          if (tc.getPostSQL() != null) {
+            try {
+              executeSQL(tc.getPostSQL(), tc.isContinueOnSqlError());
+            } catch (SQLFailureException e) {
+              getLog().error(e);
+              tc.setResultCode(TestCase.FAILURE);
+              if (!tc.isContinueOnErrors()) break;
             }
-        }
-        return m;
-    }
-    private boolean processResponse
-        (ISOMsg er, ISOMsg m, ISOMsg expected, Interpreter bsh, LogEvent evt)
-        throws ISOException, EvalError
-    {
-        int maxField = Math.max(m.getMaxField(), expected.getMaxField());
-
-        for (int i=0; i<=maxField; i++) {
-            if (expected.hasField (i)) {
-                ISOComponent c = expected.getComponent (i);
-                if (c instanceof ISOField) {
-                    String value = expected.getString (i);
-                    if (value.charAt (0) == '!' && value.length() > 1)
-                    {
-                        bsh.set  ("value", m.getString (i));
-                        Object ret = bsh.eval (value.substring (1));
-                        if (ret instanceof Boolean) {
-                            if (!(Boolean) ret) {
-                                evt.addMessage("field", "[" + i+ "] Boolean eval returned false");
-                                //return false;
-                            }
-                        } else if (ret instanceof String) {
-                            if (m.hasField(i) && !ret.equals(m.getString(i))) {
-                                evt.addMessage("field", "[" + i + "] Received:[" + m.getString(i) + "]" + " Expected:["
-                                    + ret + "]");
-                            }
-                        }
-                        m.unset (i);
-                        expected.unset (i);
-                    }
-                    else if (value.startsWith("*M")) {
-                        if (m.hasField (i)) {
-                            expected.unset (i);
-                            m.unset (i);
-                        } else {
-                            evt.addMessage("field","[" + i+ "] Mandatory field missing");
-                            //return false;
-                        }
-                    }
-                    else if (value.startsWith("*E")) {
-                        if (m.hasField (i) && er.hasField (i)) {
-                            expected.set (i, er.getString (i));
-                        } else {
-                            evt.addMessage("field", "[" + i+ "] Echo field missing");
-                            //return false;
-                        }
-                    }
-                    else if (value.startsWith("*A")) {
-                        if (m.hasField(i)) {
-                        // To make sure value is not returned for this field
-                        evt.addMessage("field", "[" + i + "] Received:[" + m.getString(i) + "]"
-                                + " Expected: Not to be set");
-                        }
-                        else {
-                            m.unset(i);
-                            expected.unset(i);
-                        }
-                    }
-                    else if (m.hasField(i) && !m.getString(i).equals(value)) {
-                        evt.addMessage("field", "[" + i+ "] Received:[" + m.getString(i) + "]" + " Expected:[" + value + "]");
-                       // return false;
-                    }
-                }
-                else if (c instanceof ISOMsg) {
-                    ISOMsg rc = (ISOMsg) m.getComponent (i);
-                    ISOMsg innerExpectedResponse = (ISOMsg) er.getComponent (i);
-                    if (rc instanceof ISOMsg) {
-                        processResponse (innerExpectedResponse, (ISOMsg) rc, (ISOMsg) c, bsh, evt);
-                    }
-                }
-            } else {
-                m.unset (i);
+          }
+          evt.addMessage(i + ": " + tc.toString());
+          if (evt_error.getPayLoad().size() != 0) {
+            evt_error.addMessage("filename", tc.getFilename());
+            evt.addMessage(NL + evt_error.toString("    "));
+          }
+          serverTime += tc.elapsed();
+          if (!tc.ok() && !tc.isContinueOnErrors()) break;
+        } else {
+          // Fire-and-forget mode: send without expecting response
+          mux.send(m);
+          tc.end();
+          // Execute post-SQL even for fire-and-forget
+          if (tc.getPostSQL() != null) {
+            try {
+              executeSQL(tc.getPostSQL(), tc.isContinueOnSqlError());
+            } catch (SQLFailureException e) {
+              getLog().error(e);
+              tc.setResultCode(TestCase.FAILURE);
+              if (!tc.isContinueOnErrors()) break;
             }
+          }
+          tc.setResultCode(TestCase.OK);
+          evt.addMessage(i + ": " + tc.toString() + " (response ignored)");
         }
-        if (evt.getPayLoad().size()!=0) {
-            return false;
-        }
-        return true;
+      }
+      if (!tc.ok()) {
+        getLog().error(tc);
+        if (!tc.isContinueOnErrors()) break;
+      }
     }
-    private boolean assertResponse (TestCase tc, Interpreter bsh, LogEvent evt)
-        throws ISOException, EvalError
-    {
-        if (tc.getResponse() == null) {
-            tc.setResultCode (TestCase.TIMEOUT);
-            return false;
-        }
-        ISOMsg c = (ISOMsg) tc.getResponse().clone();
-        ISOMsg expected = (ISOMsg) tc.getExpectedResponse().clone();
-        ISOMsg er = (ISOMsg) tc.getExpandedRequest().clone();
-        c.setHeader(tc.getResponse().getHeader());
-        if (!processResponse(er, c, expected, bsh, evt)) {
-            tc.setResultCode (TestCase.FAILURE);
-            return false;
-        }
-        expected.setPackager(null);
-        c.setPackager(null);
-        ISOPackager p = getDefaultPackager();
-        expected.setPackager(p);
-        c.setPackager(p);
+    long end = System.currentTimeMillis();
 
-        if (tc.getPostEvaluationScript() != null) {
-            bsh.set ("testcase", tc);
-            bsh.set ("response", tc.getResponse());
-            Object ret = bsh.eval (tc.getPostEvaluationScript());
-            if (ret instanceof Boolean && !(Boolean)ret) {
-                tc.setResultCode (TestCase.FAILURE);
-                return false;
-            }
-        }
-        if (expected.getHeader() == null)
-            c.setHeader((byte[]) null);
-        if (!Arrays.equals(c.pack(), expected.pack())) {
-            evt.addMessage("Pack mismatch");
-            evt.addMessage("--- expected ---");
-            evt.addMessage(ISOUtil.hexdump (expected.pack()));
-            evt.addMessage("--- actual ---");
-            evt.addMessage(ISOUtil.hexdump (c.pack()));
-            tc.setResultCode (TestCase.FAILURE);
-            return false;
-        }
-        tc.setResultCode (TestCase.OK);
-        return true;
-    }
-    private void eval (Element e, String name, Interpreter bsh)
-        throws EvalError
-    {
-        Element ee = e.getChild (name);
-        if (ee != null)
-            bsh.eval (ee.getText());
-    }
-    private Interpreter initBSH () throws UtilEvalError, EvalError {
-        Interpreter bsh = new Interpreter ();
-        BshClassManager bcm = bsh.getClassManager();
-        bcm.setClassPath(getServer().getLoader().getURLs());
-        bcm.setClassLoader(getServer().getLoader());
-        bsh.set  ("qbean", this);
-        bsh.set  ("log", getLog());
-        bsh.eval (getPersist().getChildTextTrim ("init"));
-        return bsh;
-    }
-    private ISOMsg applyRequestProps (ISOMsg m, Interpreter bsh)
-        throws ISOException, EvalError
-    {
-        int maxField = m.getMaxField();
-        for (int i=0; i<=maxField; i++) {
-            if (m.hasField(i)) {
-                ISOComponent c = m.getComponent (i);
-                if (c instanceof ISOMsg) {
-                    applyRequestProps ((ISOMsg) c, bsh);
-                } else if (c instanceof ISOField) {
-                    String value = Environment.get((String) c.getValue());
-                    if (value.length() > 0) {
-                        try {
-                            if (value.charAt (0) == '!') {
-                                m.set (i, bsh.eval (value.substring(1)).toString());
-                            }
-                            else if (value.charAt (0) == '#') {
-                                m.set (i, ISOUtil.hex2byte(bsh.eval (value.substring(1)).toString()));
-                            } 
-                            else if (!value.equals(c.getValue())) {
-                                m.set (i, value);
-                            }
-                        } catch (NullPointerException e) {
-                            m.unset (i);
-                        }
-                    }
-                }
-            }
-        }
-        return m;
-    }
-    private long percentage (long a, long b) {
-        double d = (double) a / b;
-        return (long) (d * 100.00);
-    }
+    // Calculate timing statistics
+    long simulatorTime = end - start - serverTime;
+    long total = end - start;
 
+    evt.addMessage(
+      "elapsed server=" +
+        serverTime +
+        "ms(" +
+        percentage(serverTime, total) +
+        "%)" +
+        ", simulator=" +
+        simulatorTime +
+        "ms(" +
+        percentage(simulatorTime, total) +
+        "%)" +
+        ", total=" +
+        total +
+        "ms, shutdown=" +
+        cfg.getBoolean("shutdown")
+    );
+    ISOUtil.sleep(100); // let the channel do its logging first
+    if (cfg.getBoolean("shutdown")) evt.addMessage("waiting for shutdown");
 
-    private ISOPackager getDefaultPackager() throws ISOException {
-        XMLPackager p= new XMLPackager();
+    Logger.log(evt);
+  }
+
+  /**
+   * Initializes a test suite from the XML configuration element.
+   * <p>
+   * Each &lt;test&gt; element creates a TestCase with the following properties:
+   * <ul>
+   *   <li>name: Test case name (defaults to file attribute)</li>
+   *   <li>file: Base filename for _s (send) and _r (receive) message files</li>
+   *   <li>count: Number of repetitions (default 1)</li>
+   *   <li>continue: "yes" to continue on failure (default false)</li>
+   *   <li>timeout: Per-test timeout override (default uses global timeout)</li>
+   *   <li>init: Pre-evaluation BeanShell script</li>
+   *   <li>post: Post-evaluation BeanShell script</li>
+  *   <li>pre-sql: SQL to execute before sending request</li>
+    *   <li>post-sql: SQL to execute after receiving response</li>
+    *   <li>continue-on-sql-error: "no" to fail test on SQL error (default: true/yes)</li>
+    * </ul>
+    * </p>
+   *
+   * @param suite The XML element containing test case definitions
+   * @return List of initialized TestCase objects
+   * @throws IOException if message files cannot be read
+   * @throws ISOException if message files cannot be parsed
+   */
+  private List<TestCase> initSuite(Element suite)
+    throws IOException, ISOException {
+    List<TestCase> l = new ArrayList<>();
+    String prefix = suite.getChildTextTrim("path");
+    Iterator iter = suite.getChildren("test").iterator();
+    while (iter.hasNext()) {
+      Element e = (Element) iter.next();
+      boolean cont = "yes".equals(e.getAttributeValue("continue"));
+      String s = e.getAttributeValue("count");
+      int count = s != null ? Integer.parseInt(s) : 1;
+      String path = e.getAttributeValue("file");
+      String name = e.getAttributeValue("name");
+      if (name == null) name = path;
+
+      TestCase tc = new TestCase(name);
+      tc.setCount(count);
+      tc.setContinueOnErrors(cont);
+      String coSql = e.getAttributeValue("continue-on-sql-error");
+      if (coSql != null) tc.setContinueOnSqlError("yes".equals(coSql));
+      tc.setRequest(getMessage(prefix + path + "_s"));
+      tc.setExpectedResponse(getMessage(prefix + path + "_r"));
+      tc.setPreEvaluationScript(e.getChildTextTrim("init"));
+      tc.setPostEvaluationScript(e.getChildTextTrim("post"));
+      // Parse SQL statements from XML configuration
+      tc.setPreSQL(e.getChildTextTrim("pre-sql"));
+      tc.setPostSQL(e.getChildTextTrim("post-sql"));
+      tc.setFilename(prefix + path);
+
+      String to = e.getAttributeValue("timeout");
+      if (to != null) tc.setTimeout(Long.parseLong(to));
+      else tc.setTimeout(timeout);
+      l.add(tc);
+    }
+    return l;
+  }
+
+  /**
+   * Loads an ISO message from a file.
+   * <p>
+   * The file should contain raw bytes that can be parsed by the configured packager.
+   * </p>
+   *
+   * @param filename Path to the message file
+   * @return The parsed ISOMsg, or null if file cannot be read
+   * @throws IOException if file cannot be read
+   * @throws ISOException if message cannot be parsed
+   */
+  private ISOMsg getMessage(String filename) throws IOException, ISOException {
+    File f = new File(filename);
+    ISOMsg m = null;
+    if (f.canRead()) {
+      try (FileInputStream fis = new FileInputStream(f)) {
+        byte[] b = new byte[fis.available()];
+        fis.read(b);
+        m = new ISOMsg();
+        m.setPackager(packager);
         try {
-            p.setXMLParserFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
-            p.setXMLParserFeature("http://xml.org/sax/features/external-general-entities", true);
-            p.setXMLParserFeature("http://xml.org/sax/features/external-parameter-entities", true);
-            return p;
-        } catch (SAXException e) {
-            throw new ISOException("Error creating XMLPackager", e);
+          m.unpack(b);
+        } catch (ISOException e) {
+          throw new ISOException("Error parsing '" + filename + "'", e);
+        }
+      }
+    }
+    return m;
+  }
+
+  /**
+   * Processes and validates a response message against the expected response.
+   * <p>
+   * Supports the following field value prefixes:
+   * <ul>
+   *   <li>! - Evaluate as BeanShell expression (with actual value as "value" variable)</li>
+   *   <li>*M - Field is mandatory (must be present in response)</li>
+   *   <li>*E - Echo field (copy value from request to expected)</li>
+   *   <li>*A - Field should not be present in response</li>
+   * </ul>
+   * </p>
+   *
+   * @param er Expanded request (for echo field processing)
+   * @param m Actual response received
+   * @param expected Expected response
+   * @param bsh BeanShell interpreter for ! expressions
+   * @param evt LogEvent for accumulating errors
+   * @return true if response is valid, false otherwise
+   * @throws ISOException if message processing fails
+   * @throws EvalError if script evaluation fails
+   */
+  private boolean processResponse(
+    ISOMsg er,
+    ISOMsg m,
+    ISOMsg expected,
+    Interpreter bsh,
+    LogEvent evt
+  ) throws ISOException, EvalError {
+    int maxField = Math.max(m.getMaxField(), expected.getMaxField());
+
+    for (int i = 0; i <= maxField; i++) {
+      if (expected.hasField(i)) {
+        ISOComponent c = expected.getComponent(i);
+        if (c instanceof ISOField) {
+          String value = expected.getString(i);
+          if (value.charAt(0) == '!' && value.length() > 1) {
+            // BeanShell expression evaluation
+            bsh.set("value", m.getString(i));
+            Object ret = bsh.eval(value.substring(1));
+            if (ret instanceof Boolean) {
+              if (!(Boolean) ret) {
+                evt.addMessage(
+                  "field",
+                  "[" + i + "] Boolean eval returned false"
+                );
+              }
+            } else if (ret instanceof String) {
+              if (m.hasField(i) && !ret.equals(m.getString(i))) {
+                evt.addMessage(
+                  "field",
+                  "[" +
+                    i +
+                    "] Received:[" +
+                    m.getString(i) +
+                    "]" +
+                    " Expected:[" +
+                    ret +
+                    "]"
+                );
+              }
+            }
+            m.unset(i);
+            expected.unset(i);
+          } else if (value.startsWith("*M")) {
+            // Mandatory field check
+            if (m.hasField(i)) {
+              expected.unset(i);
+              m.unset(i);
+            } else {
+              evt.addMessage("field", "[" + i + "] Mandatory field missing");
+            }
+          } else if (value.startsWith("*E")) {
+            // Echo field: copy request value to expected
+            if (m.hasField(i) && er.hasField(i)) {
+              expected.set(i, er.getString(i));
+            } else {
+              evt.addMessage("field", "[" + i + "] Echo field missing");
+            }
+          } else if (value.startsWith("*A")) {
+            // Field should NOT be present
+            if (m.hasField(i)) {
+              evt.addMessage(
+                "field",
+                "[" +
+                  i +
+                  "] Received:[" +
+                  m.getString(i) +
+                  "]" +
+                  " Expected: Not to be set"
+              );
+            } else {
+              m.unset(i);
+              expected.unset(i);
+            }
+          } else if (m.hasField(i) && !m.getString(i).equals(value)) {
+            // Direct comparison
+            evt.addMessage(
+              "field",
+              "[" +
+                i +
+                "] Received:[" +
+                m.getString(i) +
+                "]" +
+                " Expected:[" +
+                value +
+                "]"
+            );
+          }
+        } else if (c instanceof ISOMsg) {
+          // Nested message (sub-field) processing
+          ISOMsg rc = (ISOMsg) m.getComponent(i);
+          ISOMsg innerExpectedResponse = (ISOMsg) er.getComponent(i);
+          if (rc instanceof ISOMsg) {
+            processResponse(
+              innerExpectedResponse,
+              (ISOMsg) rc,
+              (ISOMsg) c,
+              bsh,
+              evt
+            );
+          }
+        }
+      } else {
+        m.unset(i);
+      }
+    }
+    if (evt.getPayLoad().size() != 0) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Asserts that the response matches the expected response.
+   * <p>
+   * This method performs the complete validation:
+   * <ol>
+   *   <li>Check for timeout (null response)</li>
+   *   <li>Process field-by-field comparison</li>
+   *   <li>Execute post-evaluation script (if configured)</li>
+   *   <li>Pack comparison (if using same packager)</li>
+   * </ol>
+   * </p>
+   *
+   * @param tc The test case with request/response data
+   * @param bsh BeanShell interpreter for script evaluation
+   * @param evt LogEvent for accumulating errors
+   * @return true if response is valid, false otherwise
+   * @throws ISOException if message processing fails
+   * @throws EvalError if script evaluation fails
+   */
+  private boolean assertResponse(TestCase tc, Interpreter bsh, LogEvent evt)
+    throws ISOException, EvalError {
+    if (tc.getResponse() == null) {
+      tc.setResultCode(TestCase.TIMEOUT);
+      return false;
+    }
+    ISOMsg c = (ISOMsg) tc.getResponse().clone();
+    ISOMsg expected = (ISOMsg) tc.getExpectedResponse().clone();
+    ISOMsg er = (ISOMsg) tc.getExpandedRequest().clone();
+    c.setHeader(tc.getResponse().getHeader());
+    if (!processResponse(er, c, expected, bsh, evt)) {
+      tc.setResultCode(TestCase.FAILURE);
+      return false;
+    }
+    expected.setPackager(null);
+    c.setPackager(null);
+    ISOPackager p = getDefaultPackager();
+    expected.setPackager(p);
+    c.setPackager(p);
+
+    // Execute post-evaluation script if configured
+    if (tc.getPostEvaluationScript() != null) {
+      bsh.set("testcase", tc);
+      bsh.set("response", tc.getResponse());
+      Object ret = bsh.eval(tc.getPostEvaluationScript());
+      if (ret instanceof Boolean && !(Boolean) ret) {
+        tc.setResultCode(TestCase.FAILURE);
+        return false;
+      }
+    }
+    if (expected.getHeader() == null) c.setHeader((byte[]) null);
+    // Final pack comparison
+    if (!Arrays.equals(c.pack(), expected.pack())) {
+      evt.addMessage("Pack mismatch");
+      evt.addMessage("--- expected ---");
+      evt.addMessage(ISOUtil.hexdump(expected.pack()));
+      evt.addMessage("--- actual ---");
+      evt.addMessage(ISOUtil.hexdump(c.pack()));
+      tc.setResultCode(TestCase.FAILURE);
+      return false;
+    }
+    tc.setResultCode(TestCase.OK);
+    return true;
+  }
+
+  /**
+   * Evaluates a BeanChild script from an XML element.
+   *
+   * @param e Parent element
+   * @param name Child element name containing the script
+   * @param bsh BeanShell interpreter
+   * @throws EvalError if script evaluation fails
+   */
+  private void eval(Element e, String name, Interpreter bsh) throws EvalError {
+    Element ee = e.getChild(name);
+    if (ee != null) bsh.eval(ee.getText());
+  }
+
+  /**
+   * Initializes the BeanShell interpreter with jPOS environment and classpath.
+   *
+   * @return Configured BeanShell interpreter
+   * @throws UtilEvalError if class manager setup fails
+   * @throws EvalError if initial script evaluation fails
+   */
+  private Interpreter initBSH() throws UtilEvalError, EvalError {
+    Interpreter bsh = new Interpreter();
+    BshClassManager bcm = bsh.getClassManager();
+    bcm.setClassPath(getServer().getLoader().getURLs());
+    bcm.setClassLoader(getServer().getLoader());
+    bsh.set("qbean", this);
+    bsh.set("log", getLog());
+    bsh.eval(getPersist().getChildTextTrim("init"));
+    return bsh;
+  }
+
+  /**
+   * Applies property substitutions to a request message.
+   * <p>
+   * Supports the following value prefixes:
+   * <ul>
+   *   <li>$ - Standard property substitution via {@link Environment}</li>
+   *   <li>! - BeanShell expression (evaluated dynamically)</li>
+   *   <li># - Hex string to bytes conversion</li>
+   * </ul>
+   * </p>
+   *
+   * @param m The request message to modify
+   * @param bsh BeanShell interpreter for ! expressions
+   * @return The modified message
+   * @throws ISOException if message processing fails
+   * @throws EvalError if script evaluation fails
+   */
+  private ISOMsg applyRequestProps(ISOMsg m, Interpreter bsh)
+    throws ISOException, EvalError {
+    int maxField = m.getMaxField();
+    for (int i = 0; i <= maxField; i++) {
+      if (m.hasField(i)) {
+        ISOComponent c = m.getComponent(i);
+        if (c instanceof ISOMsg) {
+          // Recursively process nested messages
+          applyRequestProps((ISOMsg) c, bsh);
+        } else if (c instanceof ISOField) {
+          String value = Environment.get((String) c.getValue());
+          if (value.length() > 0) {
+            try {
+              if (value.charAt(0) == '!') {
+                // Dynamic BeanShell expression
+                m.set(i, bsh.eval(value.substring(1)).toString());
+              } else if (value.charAt(0) == '#') {
+                // Hex to bytes conversion
+                m.set(
+                  i,
+                  ISOUtil.hex2byte(bsh.eval(value.substring(1)).toString())
+                );
+              } else if (!value.equals(c.getValue())) {
+                // Standard property replacement
+                m.set(i, value);
+              }
+            } catch (NullPointerException e) {
+              m.unset(i);
+            }
+          }
+        }
+      }
+    }
+    return m;
+  }
+
+  /**
+   * Calculates percentage value.
+   *
+   * @param a Numerator
+   * @param b Denominator
+   * @return (a / b) * 100 as long
+   */
+  private long percentage(long a, long b) {
+    double d = (double) a / b;
+    return (long) (d * 100.00);
+  }
+
+   /**
+     * Executes SQL statement(s) using the Hibernate-managed database connection.
+     * <p>
+     * This method:
+     * <ul>
+     *   <li>Opens a connection via {@link DB}</li>
+     *   <li>Begins a transaction</li>
+     *   <li>Splits SQL by semicolons and executes each statement</li>
+     *   <li>Logs SELECT result sets with row data</li>
+     *   <li>Logs affected row count for INSERT/UPDATE/DELETE</li>
+     *   <li>Commits the transaction on success</li>
+     *   <li>Rolls back the transaction on failure if {@code continueOnError} is false</li>
+     * </ul>
+     * </p>
+     * <p>
+     * If the SQL is null, empty, or whitespace-only, the method returns immediately
+     * without any database operations.
+     * </p>
+     * <p>
+      * When {@code continueOnError} is false and an error occurs, a {@link SQLFailureException}
+     * is thrown to stop test execution. When true, errors are logged but the method returns normally.
+     * </p>
+     * <p>
+     * Note: The database connection is configured via cfg/db.properties which
+     * should contain Hibernate connection properties (url, username, password, driver).
+     * </p>
+     *
+     * @param sql SQL statement(s) to execute. Multiple statements separated by semicolons.
+      * @param continueOnError if false, throws {@link SQLFailureException} on error
+     * @see DB
+     * @see TestCase#getPreSQL()
+     * @see TestCase#getPostSQL()
+     */
+    private void executeSQL (String sql, boolean continueOnError) {
+        // Guard clause: skip null or empty SQL
+        if (sql == null || sql.trim().isEmpty()) {
+            return;
+        }
+        try (DB db = new DB()) {
+            db.open();
+            db.beginTransaction();
+            // Use Hibernate's Work interface to access JDBC connection
+            db.session().doWork(new Work() {
+                @Override
+                public void execute(Connection conn) throws java.sql.SQLException {
+                    try (Statement stmt = conn.createStatement()) {
+                        // Split by semicolon to support multiple statements
+                        String[] queries = sql.split(";");
+                        for (String q : queries) {
+                            q = q.trim();
+                            if (q.length() > 0) {
+                                boolean isResultSet = stmt.execute(q);
+                                LogEvent evt = getLog().createLogEvent("SQL");
+                                evt.addMessage("Executed: " + q);
+
+                                if (isResultSet) {
+                                    // SELECT-type query - log result set
+                                    java.sql.ResultSet rs = stmt.getResultSet();
+                                    java.sql.ResultSetMetaData rsmd = rs.getMetaData();
+                                    int cols = rsmd.getColumnCount();
+                                    while (rs.next()) {
+                                        StringBuilder sb = new StringBuilder("Row: ");
+                                        for (int i = 1; i <= cols; i++) {
+                                            sb.append(rsmd.getColumnName(i))
+                                              .append("=")
+                                              .append(rs.getString(i))
+                                              .append(" ");
+                                        }
+                                        evt.addMessage(sb.toString());
+                                    }
+                                    rs.close();
+                                } else {
+                                    // INSERT/UPDATE/DELETE - log affected rows
+                                    evt.addMessage("Rows affected: " + stmt.getUpdateCount());
+                                }
+                                Logger.log(evt);
+                            }
+                        }
+                    }
+                }
+            });
+            db.commit();
+        } catch (Exception e) {
+            if (!continueOnError) {
+                // Rollback is handled by DB.close() / transaction management
+                throw new SQLFailureException(sql, e);
+            } else {
+                // Log error but don't throw - let test continue
+                getLog().error("SQL Error: " + sql, e);
+            }
         }
     }
 
-}
+    /**
+     * Executes SQL statement(s) using the Hibernate-managed database connection.
+     * <p>
+     * Convenience overload that logs errors but does not throw exceptions.
+     * Equivalent to {@link #executeSQL(String, boolean)} with {@code continueOnError=true}.
+     * </p>
+     *
+     * @param sql SQL statement(s) to execute. Multiple statements separated by semicolons.
+     */
+    private void executeSQL (String sql) {
+        executeSQL(sql, true);
+    }
 
+    /**
+   * Creates a default XMLPackager for parsing message files.
+   *
+   * @return A configured XMLPackager instance
+   * @throws ISOException if packager cannot be created
+   */
+  private ISOPackager getDefaultPackager() throws ISOException {
+    XMLPackager p = new XMLPackager();
+    try {
+      p.setXMLParserFeature(
+        "http://apache.org/xml/features/disallow-doctype-decl",
+        false
+      );
+      p.setXMLParserFeature(
+        "http://xml.org/sax/features/external-general-entities",
+        true
+      );
+      p.setXMLParserFeature(
+        "http://xml.org/sax/features/external-parameter-entities",
+        true
+      );
+      return p;
+    } catch (SAXException e) {
+      throw new ISOException("Error creating XMLPackager", e);
+    }
+  }
+}

--- a/modules/client-simulator/src/main/java/org/jpos/simulator/TestRunner.java
+++ b/modules/client-simulator/src/main/java/org/jpos/simulator/TestRunner.java
@@ -45,9 +45,11 @@ import org.xml.sax.SAXException;
 
 /**
  * TestRunner executes a suite of simulator test cases against an ISO-8583 MUX.
+ *
  * <p>
  * TestRunner is a QBean that loads test case definitions from an XML configuration
  * and executes them sequentially. Each test case can include:
+ *
  * <ul>
  *   <li>Pre-evaluation BeanShell scripts (to prepare request data)</li>
  *   <li>Pre-SQL statements (to perform database operations before the request)</li>
@@ -55,9 +57,8 @@ import org.xml.sax.SAXException;
  *   <li>Post-SQL statements (to perform database operations after the response)</li>
  *   <li>Post-evaluation BeanShell scripts (to validate response data)</li>
  * </ul>
- * </p>
- * <p>
- * Configuration example in a Q2 deploy.xml:
+ *
+ * <p>Configuration example in a Q2 deploy.xml:
  * <pre>
  * &lt;test-runner realm="simulator" class="org.jpos.simulator.TestRunner"&gt;
  *     &lt;property name="mux" value="mux.selector"/&gt;
@@ -75,7 +76,6 @@ import org.xml.sax.SAXException;
  *     &lt;/test-suite&gt;
  * &lt;/test-runner&gt;
  * </pre>
- * </p>
  *
  * @author Alejandro P. Revilla
  * @author <a href="mailto:support@jpos.org">jPOS Support Team</a>
@@ -186,32 +186,32 @@ public class TestRunner extends org.jpos.q2.QBeanSupport implements Runnable {
     }
   }
 
- /**
-    * Runs the complete test suite, executing each test case in order.
-    * <p>
-    * For each test case:
-    * <ol>
-    *   <li>Execute pre-evaluation script (if configured)</li>
-     *   <li>Execute pre-SQL (if configured) — catches {@link SQLFailureException}</li>
-    *   <li>Clone and expand the request message</li>
-    *   <li>Send request to MUX and measure elapsed time</li>
-     *   <li>Execute post-SQL (if configured and response was expected) — catches {@link SQLFailureException}</li>
-    *   <li>Validate response and set result code</li>
-    * </ol>
-    * </p>
-    * <p>
-    * When {@code continue-on-sql-error="no"} is set on a test case, SQL execution failures
-    * are caught, logged, and cause the test to fail. If {@code continue="yes"} is also set,
-    * subsequent tests will still run.
-    * </p>
-    *
-    * @param suite List of TestCase objects to execute
-    * @param mux The MUX to use for sending/receiving messages
-    * @param bsh BeanShell interpreter for script evaluation
-    * @throws ISOException if message processing fails
-    * @throws IOException if file operations fail
-    * @throws EvalError if script evaluation fails
-    */
+  /**
+   * Runs the complete test suite, executing each test case in order.
+   *
+   * <p>For each test case:
+   *
+   * <ol>
+   *   <li>Execute pre-evaluation script (if configured)</li>
+   *   <li>Execute pre-SQL (if configured) — catches {@link SQLFailureException}</li>
+   *   <li>Clone and expand the request message</li>
+   *   <li>Send request to MUX and measure elapsed time</li>
+   *   <li>Execute post-SQL (if configured and response was expected) — catches {@link SQLFailureException}</li>
+   *   <li>Validate response and set result code</li>
+   * </ol>
+   *
+   * <p>When {@code continue-on-sql-error="no"} is set on a test case, SQL execution failures
+   * are caught, logged, and cause the test to fail. If {@code continue="yes"} is also set,
+   * subsequent tests will still run.
+   * </p>
+   *
+   * @param suite List of TestCase objects to execute
+   * @param mux   The MUX to use for sending/receiving messages
+   * @param bsh   BeanShell interpreter for script evaluation
+   * @throws ISOException if message processing fails
+   * @throws IOException  if file operations fail
+   * @throws EvalError    if script evaluation fails
+   */
   private void runSuite(List suite, MUX mux, Interpreter bsh)
     throws ISOException, IOException, EvalError {
     LogEvent evt = getLog().createLogEvent("results");
@@ -243,7 +243,7 @@ public class TestRunner extends org.jpos.q2.QBeanSupport implements Runnable {
           } catch (SQLFailureException e) {
             getLog().error(e);
             tc.setResultCode(TestCase.FAILURE);
-            if (!tc.isContinueOnErrors()) break;
+            break;
           }
         }
         // Apply property substitutions and expand request
@@ -261,7 +261,7 @@ public class TestRunner extends org.jpos.q2.QBeanSupport implements Runnable {
             } catch (SQLFailureException e) {
               getLog().error(e);
               tc.setResultCode(TestCase.FAILURE);
-              if (!tc.isContinueOnErrors()) break;
+              break;
             }
           }
           evt.addMessage(i + ": " + tc.toString());
@@ -282,10 +282,11 @@ public class TestRunner extends org.jpos.q2.QBeanSupport implements Runnable {
             } catch (SQLFailureException e) {
               getLog().error(e);
               tc.setResultCode(TestCase.FAILURE);
-              if (!tc.isContinueOnErrors()) break;
+              break;
             }
           }
-          tc.setResultCode(TestCase.OK);
+          if (tc.getResultCode() == -1)
+            tc.setResultCode(TestCase.OK);
           evt.addMessage(i + ": " + tc.toString() + " (response ignored)");
         }
       }
@@ -324,8 +325,9 @@ public class TestRunner extends org.jpos.q2.QBeanSupport implements Runnable {
 
   /**
    * Initializes a test suite from the XML configuration element.
-   * <p>
-   * Each &lt;test&gt; element creates a TestCase with the following properties:
+   *
+   * <p>Each &lt;test&gt; element creates a TestCase with the following properties:
+   *
    * <ul>
    *   <li>name: Test case name (defaults to file attribute)</li>
    *   <li>file: Base filename for _s (send) and _r (receive) message files</li>
@@ -334,15 +336,14 @@ public class TestRunner extends org.jpos.q2.QBeanSupport implements Runnable {
    *   <li>timeout: Per-test timeout override (default uses global timeout)</li>
    *   <li>init: Pre-evaluation BeanShell script</li>
    *   <li>post: Post-evaluation BeanShell script</li>
-  *   <li>pre-sql: SQL to execute before sending request</li>
-    *   <li>post-sql: SQL to execute after receiving response</li>
-    *   <li>continue-on-sql-error: "no" to fail test on SQL error (default: true/yes)</li>
-    * </ul>
-    * </p>
+   *   <li>pre-sql: SQL to execute before sending request</li>
+   *   <li>post-sql: SQL to execute after receiving response</li>
+   *   <li>continue-on-sql-error: "no" to fail test on SQL error (default: true/yes)</li>
+   * </ul>
    *
    * @param suite The XML element containing test case definitions
    * @return List of initialized TestCase objects
-   * @throws IOException if message files cannot be read
+   * @throws IOException  if message files cannot be read
    * @throws ISOException if message files cannot be parsed
    */
   private List<TestCase> initSuite(Element suite)
@@ -703,10 +704,11 @@ public class TestRunner extends org.jpos.q2.QBeanSupport implements Runnable {
     return (long) (d * 100.00);
   }
 
-   /**
+    /**
      * Executes SQL statement(s) using the Hibernate-managed database connection.
-     * <p>
-     * This method:
+     *
+     * <p>This method:
+     *
      * <ul>
      *   <li>Opens a connection via {@link DB}</li>
      *   <li>Begins a transaction</li>
@@ -716,13 +718,12 @@ public class TestRunner extends org.jpos.q2.QBeanSupport implements Runnable {
      *   <li>Commits the transaction on success</li>
      *   <li>Rolls back the transaction on failure if {@code continueOnError} is false</li>
      * </ul>
-     * </p>
-     * <p>
-     * If the SQL is null, empty, or whitespace-only, the method returns immediately
+     *
+     * <p>If the SQL is null, empty, or whitespace-only, the method returns immediately
      * without any database operations.
      * </p>
      * <p>
-      * When {@code continueOnError} is false and an error occurs, a {@link SQLFailureException}
+     * When {@code continueOnError} is false and an error occurs, a {@link SQLFailureException}
      * is thrown to stop test execution. When true, errors are logged but the method returns normally.
      * </p>
      * <p>
@@ -730,8 +731,8 @@ public class TestRunner extends org.jpos.q2.QBeanSupport implements Runnable {
      * should contain Hibernate connection properties (url, username, password, driver).
      * </p>
      *
-     * @param sql SQL statement(s) to execute. Multiple statements separated by semicolons.
-      * @param continueOnError if false, throws {@link SQLFailureException} on error
+     * @param sql             SQL statement(s) to execute. Multiple statements separated by semicolons.
+     * @param continueOnError if false, throws {@link SQLFailureException} on error
      * @see DB
      * @see TestCase#getPreSQL()
      * @see TestCase#getPostSQL()

--- a/modules/client-simulator/src/test/java/org/jpos/simulator/TestBase.java
+++ b/modules/client-simulator/src/test/java/org/jpos/simulator/TestBase.java
@@ -1,0 +1,208 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.simulator;
+
+import org.jpos.ee.DB;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+/**
+ * Base test class for client-simulator tests.
+ * <p>
+ * This class sets up a database using Testcontainers for testing SQL functionality.
+ * It supports both PostgreSQL and MySQL. It provides:
+ * <ul>
+ *   <li>Automatic database container lifecycle management</li>
+ *   <li>Database properties file creation for Hibernate</li>
+ *   <li>Session factory invalidation between tests</li>
+ * </ul>
+ * </p>
+ * <p>
+ * The database configuration can be controlled via the system property
+ * {@code test.clientsim_db_driver}:
+ * <ul>
+ *   <li>"postgres" (default) - Use Testcontainers with PostgreSQL 17</li>
+ *   <li>"mysql" - Use Testcontainers with MySQL 8</li>
+ *   <li>"local" - Use a local database instance (requires system properties set)</li>
+ * </ul>
+ * </p>
+ * <p>
+ * When using local database, set these system properties before running:
+ * <ul>
+ *   <li>db.connection - JDBC URL</li>
+ *   <li>db.username - Database username</li>
+ *   <li>db.password - Database password</li>
+ *   <li>db.driver - JDBC driver class name</li>
+ * </ul>
+ * </p>
+ *
+ * @see TestCaseSQLTest
+ * @see TestRunnerSQLTest
+ * @see <a href="https://www.testcontainers.org/">Testcontainers Documentation</a>
+ */
+@TestInstance(PER_CLASS)
+public abstract class TestBase {
+    /**
+     * Temporary directory for test files.
+     * JUnit Jupiter will inject this automatically.
+     */
+    @TempDir
+    protected static File tempDir;
+
+    /**
+     * Optional config modifier for multi-database configurations.
+     * Default is null (uses default database).
+     */
+    protected static String configModifier = null;
+
+    /**
+     * PostgreSQL container for test database.
+     * Container is reused across tests for performance.
+     */
+    private static final PostgreSQLContainer<?> PG_CONTAINER =
+      new PostgreSQLContainer<>("postgres:17")
+        .withDatabaseName("jposee")
+        .withUsername("jpos")
+        .withPassword("password")
+        .withReuse(true);
+
+    /**
+     * MySQL container for test database.
+     * Container is reused across tests for performance.
+     */
+    private static final MySQLContainer<?> MYSQL_CONTAINER =
+      new MySQLContainer<>("mysql:8")
+        .withDatabaseName("jposee")
+        .withUsername("jpos")
+        .withPassword("password")
+        .withReuse(true);
+
+    /**
+     * Sets up the test database before all tests run.
+     * <p>
+     * This method:
+     * <ol>
+     *   <li>Determines database source (Testcontainers PostgreSQL, MySQL, or local)</li>
+     *   <li>Configures system properties for database connection</li>
+     *   <li>Invalidates any existing session factory</li>
+     *   <li>Creates cfg/db.properties for Hibernate</li>
+     * </ol>
+     * </p>
+     *
+     * @throws Exception if setup fails
+     */
+    @BeforeAll
+    public static void setUpBase () throws Exception {
+        String driver = System.getProperty("test.clientsim_db_driver", "postgres");
+        if ("local".equals(driver)) {
+            // Use pre-configured local database - set properties externally
+        } else if ("mysql".equals(driver)) {
+            // Start Testcontainers MySQL
+            if (!MYSQL_CONTAINER.isRunning())
+                MYSQL_CONTAINER.start();
+            System.setProperty("db.connection", MYSQL_CONTAINER.getJdbcUrl());
+            System.setProperty("db.username", MYSQL_CONTAINER.getUsername());
+            System.setProperty("db.password", MYSQL_CONTAINER.getPassword());
+            System.setProperty("db.driver", "com.mysql.cj.jdbc.Driver");
+        } else {
+            // Start Testcontainers PostgreSQL (default)
+            if (!PG_CONTAINER.isRunning())
+                PG_CONTAINER.start();
+            System.setProperty("db.connection", PG_CONTAINER.getJdbcUrl());
+            System.setProperty("db.username", PG_CONTAINER.getUsername());
+            System.setProperty("db.password", PG_CONTAINER.getPassword());
+            System.setProperty("db.driver", "org.postgresql.Driver");
+        }
+        // Ensure clean session factory state
+        DB.invalidateSessionFactory(configModifier);
+        writeDbProperties();
+    }
+
+    /**
+     * Cleans up database resources after all tests complete.
+     * <p>
+     * This method:
+     * <ol>
+     *   <li>Invalidates the session factory to release connections</li>
+     *   <li>Deletes the test-generated cfg/db.properties file</li>
+     * </ol>
+     * </p>
+     *
+     * @throws Exception if cleanup fails
+     */
+    @AfterAll
+    public static void tearDownBase () throws Exception {
+        DB.invalidateSessionFactory(configModifier);
+        // Clean up test-generated db.properties
+        File dbProps = new File("cfg/db.properties");
+        if (dbProps.exists()) {
+            dbProps.delete();
+        }
+    }
+
+    /**
+     * Creates cfg/db.properties with Hibernate connection settings.
+     * <p>
+     * The properties file configures:
+     * <ul>
+     *   <li>Agroal connection pool (for performance)</li>
+     *   <li>Connection credentials from system properties</li>
+     *   <li>Connection pool size limits</li>
+     * </ul>
+     * </p>
+     *
+     * @throws IOException if file write fails
+     */
+    private static void writeDbProperties() throws IOException {
+        File cfgDir = new File("cfg");
+        if (!cfgDir.exists())
+            cfgDir.mkdirs();
+        Properties props = new Properties();
+        props.setProperty("hibernate.connection.provider_class", "org.hibernate.agroal.internal.AgroalConnectionProvider");
+        props.setProperty("hibernate.connection.username", System.getProperty("db.username"));
+        props.setProperty("hibernate.connection.password", System.getProperty("db.password"));
+        props.setProperty("hibernate.connection.url", System.getProperty("db.connection"));
+        props.setProperty("hibernate.connection.driver_class", System.getProperty("db.driver"));
+        props.setProperty("hibernate.agroal.minSize", "1");
+        props.setProperty("hibernate.agroal.maxSize", "8");
+        try (FileOutputStream fos = new FileOutputStream(new File(cfgDir, "db.properties"))) {
+            props.store(fos, null);
+        }
+    }
+
+    /**
+     * Helper method to determine if tests are running against MySQL.
+     *
+     * @return true if MySQL driver is selected, false for PostgreSQL
+     */
+    protected static boolean isMySQL() {
+        return "mysql".equals(System.getProperty("test.clientsim_db_driver", "postgres"));
+    }
+}

--- a/modules/client-simulator/src/test/java/org/jpos/simulator/TestCaseBackwardCompatTest.java
+++ b/modules/client-simulator/src/test/java/org/jpos/simulator/TestCaseBackwardCompatTest.java
@@ -1,0 +1,273 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.simulator;
+
+import org.jpos.iso.ISOMsg;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Backward compatibility tests for TestCase.
+ * <p>
+ * These tests verify that existing TestCase usage without SQL continues to work.
+ * Specifically tests:
+ * <ul>
+ *   <li>TestCase created without SQL fields still functions normally</li>
+ *   <li>Dump output does NOT contain SQL elements when no SQL set</li>
+ *   <li>All existing result codes work</li>
+ *   <li>Pre/post evaluation scripts work alongside SQL fields</li>
+ *   <li>null SQL fields don't cause issues</li>
+ *   <li>continueOnSqlError defaults to true (backward compatible)</li>
+ * </ul>
+ * </p>
+ *
+ * @see TestCase
+ */
+public class TestCaseBackwardCompatTest extends TestBase {
+
+    /**
+     * Creates a TestCase with minimal required messages for dump operations.
+     */
+    private TestCase createMinimalTestCase() {
+        TestCase tc = new TestCase("legacy-test");
+        tc.setRequest(new ISOMsg());
+        tc.setExpectedResponse(new ISOMsg());
+        return tc;
+    }
+
+    /**
+     * Tests that a TestCase created the old way (no SQL) works normally.
+     * <p>
+     * This simulates the pre-SQL era where only init/post scripts were used.
+     */
+    @Test
+    public void testTestCaseWithoutSQLFields() {
+        TestCase tc = new TestCase("authorization-test");
+
+        // SQL fields should be null by default (backward compatible)
+        assertNull(tc.getPreSQL(), "preSQL should be null when not set");
+        assertNull(tc.getPostSQL(), "postSQL should be null when not set");
+
+        // Script fields should also be null (existing behavior)
+        assertNull(tc.getPreEvaluationScript());
+        assertNull(tc.getPostEvaluationScript());
+
+        // Result code should be -1 (unset)
+        assertEquals(-1, tc.getResultCode());
+
+        // Test should NOT be ok() when result code is unset
+        assertFalse(tc.ok());
+    }
+
+    /**
+     * Tests that dump() does NOT include SQL elements when no SQL configured.
+     * <p>
+     * This ensures existing XML output remains unchanged for legacy test cases.
+     */
+    @Test
+    public void testDumpWithoutSQLDoesNotContainSqlElements() {
+        TestCase tc = createMinimalTestCase();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        tc.dump(new PrintStream(baos), "  ");
+
+        String output = baos.toString();
+
+        // SQL elements should NOT appear in output
+        assertFalse(output.contains("<pre-sql>"), "pre-sql should not appear when preSQL is null");
+        assertFalse(output.contains("<post-sql>"), "post-sql should not appear when postSQL is null");
+
+        // Normal elements should still be present
+        assertTrue(output.contains("<test-case"), "test-case element should be present");
+        assertTrue(output.contains("<request>"), "request element should be present");
+        assertTrue(output.contains("<expected-response>"), "expected-response element should be present");
+    }
+
+    /**
+     * Tests that existing pre/post evaluation scripts still work.
+     * <p>
+     * SQL fields are nullable and independent of script fields.
+     */
+    @Test
+    public void testScriptsWorkIndependentlyOfSQL() {
+        TestCase tc = new TestCase("test");
+
+        // Set scripts (existing functionality)
+        tc.setPreEvaluationScript("request.set(7, \"123456789\");");
+        tc.setPostEvaluationScript("return response.getString(39).equals(\"00\");");
+
+        // SQL fields remain null (new optional feature)
+        assertNull(tc.getPreSQL());
+        assertNull(tc.getPostSQL());
+
+        // Both script fields are set
+        assertNotNull(tc.getPreEvaluationScript());
+        assertNotNull(tc.getPostEvaluationScript());
+    }
+
+    /**
+     * Tests that SQL fields can be set alongside existing fields.
+     */
+    @Test
+    public void testSQLAndScriptsCanCoexist() {
+        TestCase tc = new TestCase("test");
+
+        // Set both scripts AND SQL (new combined usage)
+        tc.setPreEvaluationScript("request.set(7, \"123456789\");");
+        tc.setPreSQL("INSERT INTO audit_log VALUES ('start')");
+        tc.setPostEvaluationScript("return response.getString(39).equals(\"00\");");
+        tc.setPostSQL("UPDATE test SET status='done'");
+
+        // All fields should be set
+        assertNotNull(tc.getPreEvaluationScript());
+        assertNotNull(tc.getPreSQL());
+        assertNotNull(tc.getPostEvaluationScript());
+        assertNotNull(tc.getPostSQL());
+    }
+
+    /**
+     * Tests that result codes remain unchanged.
+     */
+    @Test
+    public void testResultCodesUnchanged() {
+        TestCase tc = new TestCase("test");
+
+        // OK (0)
+        tc.setResultCode(TestCase.OK);
+        assertEquals("OK", tc.getResultCodeAsString());
+        assertTrue(tc.ok());
+
+        // FAILURE (1)
+        tc.setResultCode(TestCase.FAILURE);
+        assertEquals("FAILURE", tc.getResultCodeAsString());
+        assertFalse(tc.ok());
+
+        // TIMEOUT (2)
+        tc.setResultCode(TestCase.TIMEOUT);
+        assertEquals("TIMEOUT", tc.getResultCodeAsString());
+        assertFalse(tc.ok());
+    }
+
+    /**
+     * Tests that timeout and continueOnErrors work as before.
+     */
+    @Test
+    public void testTimeoutAndContinueSettingsUnchanged() {
+        TestCase tc = new TestCase("test");
+
+        // Default values
+        assertEquals(0, tc.getTimeout(), "Default timeout should be 0");
+        assertFalse(tc.isContinueOnErrors(), "Default continueOnErrors should be false");
+
+        // Set custom values
+        tc.setTimeout(30000);
+        tc.setContinueOnErrors(true);
+
+        assertEquals(30000, tc.getTimeout());
+        assertTrue(tc.isContinueOnErrors());
+    }
+
+    /**
+     * Tests that start/end/elapsed work correctly without SQL.
+     */
+    @Test
+    public void testTimingWorksWithoutSQL() {
+        TestCase tc = new TestCase("test");
+
+        assertEquals(0, tc.elapsed(), "Elapsed should be 0 before start()");
+
+        tc.start();
+        try {
+            Thread.sleep(10); // Small delay
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        tc.end();
+
+        assertTrue(tc.elapsed() >= 10, "Elapsed should be at least 10ms after 10ms sleep");
+    }
+
+    /**
+     * Tests that setFilename works as before.
+     */
+    @Test
+    public void testFilenameSettingUnchanged() {
+        TestCase tc = new TestCase("test");
+
+        assertNull(tc.getFilename(), "Filename should be null initially");
+
+        tc.setFilename("/path/to/test_0200");
+        assertEquals("/path/to/test_0200", tc.getFilename());
+    }
+
+    /**
+     * Tests that continueOnSqlError defaults to true for backward compatibility.
+     * <p>
+     * Existing test configurations without continue-on-sql-error attribute
+     * should continue to work (SQL errors logged but not thrown).
+     * </p>
+     */
+    @Test
+    public void testContinueOnSqlErrorDefaultsToTrue() {
+        TestCase tc = new TestCase("legacy-test");
+        assertTrue(tc.isContinueOnSqlError(), "continueOnSqlError should default to true for backward compatibility");
+    }
+
+    /**
+     * Tests that legacy tests without SQL can still set continueOnSqlError.
+     */
+    @Test
+    public void testLegacyTestsCanSetContinueOnSqlError() {
+        TestCase tc = new TestCase("legacy-test");
+
+        // Default is true (backward compatible)
+        assertTrue(tc.isContinueOnSqlError());
+
+        // Can be explicitly set to false for stricter SQL error handling
+        tc.setContinueOnSqlError(false);
+        assertFalse(tc.isContinueOnSqlError());
+
+        // Legacy behavior restored by default
+        tc.setContinueOnSqlError(true);
+        assertTrue(tc.isContinueOnSqlError());
+    }
+
+    /**
+     * Tests that continueOnSqlError is independent of continueOnErrors.
+     */
+    @Test
+    public void testContinueOnSqlErrorIndependentOfContinueOnErrors() {
+        TestCase tc = new TestCase("test");
+
+        // Defaults: continueOnErrors=false, continueOnSqlError=true
+        assertFalse(tc.isContinueOnErrors());
+        assertTrue(tc.isContinueOnSqlError());
+
+        // Can be set independently
+        tc.setContinueOnErrors(true);
+        tc.setContinueOnSqlError(false);
+
+        assertTrue(tc.isContinueOnErrors());
+        assertFalse(tc.isContinueOnSqlError());
+    }
+}

--- a/modules/client-simulator/src/test/java/org/jpos/simulator/TestCaseSQLTest.java
+++ b/modules/client-simulator/src/test/java/org/jpos/simulator/TestCaseSQLTest.java
@@ -1,0 +1,229 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.simulator;
+
+import org.jpos.iso.ISOMsg;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for SQL-related functionality in TestCase.
+ * <p>
+ * Tests cover:
+ * <ul>
+ *   <li>Pre-SQL and Post-SQL getter/setter methods</li>
+ *   <li>XML dump output for SQL elements</li>
+ *   <li>Result code string representations</li>
+ *   <li>continueOnSqlError field getter/setter</li>
+ *   <li>SQLFailureException behavior</li>
+ * </ul>
+ * </p>
+ *
+ * @see TestCase
+ * @see TestBase
+ */
+public class TestCaseSQLTest extends TestBase {
+
+    /**
+     * Creates a minimal TestCase with request/response messages set.
+     * <p>
+     * This is needed because TestCase.dump() accesses request and expectedResponse.
+     * </p>
+     *
+     * @return A configured TestCase instance
+     */
+    private TestCase createTestCase() {
+        TestCase tc = new TestCase("test-case");
+        tc.setRequest(new ISOMsg());
+        tc.setExpectedResponse(new ISOMsg());
+        return tc;
+    }
+
+    /**
+     * Tests that pre-SQL getter/setter work correctly.
+     */
+    @Test
+    public void testPreSQLGetterSetter() {
+        TestCase tc = new TestCase("test-case");
+
+        // Initially null
+        assertNull(tc.getPreSQL());
+
+        // Set value
+        tc.setPreSQL("SELECT * FROM users");
+        assertEquals("SELECT * FROM users", tc.getPreSQL());
+    }
+
+    /**
+     * Tests that post-SQL getter/setter work correctly.
+     */
+    @Test
+    public void testPostSQLGetterSetter() {
+        TestCase tc = new TestCase("test-case");
+
+        // Initially null
+        assertNull(tc.getPostSQL());
+
+        // Set value
+        tc.setPostSQL("UPDATE users SET last_access = NOW()");
+        assertEquals("UPDATE users SET last_access = NOW()", tc.getPostSQL());
+    }
+
+    /**
+     * Tests that dump() outputs pre-sql element when preSQL is set.
+     */
+    @Test
+    public void testDumpWithPreSQLOnly() {
+        TestCase tc = createTestCase();
+        tc.setPreSQL("SELECT 1");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        tc.dump(new PrintStream(baos), "  ");
+
+        String output = baos.toString();
+        assertTrue(output.contains("<pre-sql>"), "Should contain pre-sql element");
+        assertTrue(output.contains("SELECT 1"), "Should contain pre-sql value");
+        assertFalse(output.contains("<post-sql>"), "Should not contain post-sql element when null");
+    }
+
+    /**
+     * Tests that dump() outputs post-sql element when postSQL is set.
+     */
+    @Test
+    public void testDumpWithPostSQLOnly() {
+        TestCase tc = createTestCase();
+        tc.setPostSQL("SELECT 2");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        tc.dump(new PrintStream(baos), "  ");
+
+        String output = baos.toString();
+        assertFalse(output.contains("<pre-sql>"), "Should not contain pre-sql element when null");
+        assertTrue(output.contains("<post-sql>"), "Should contain post-sql element");
+        assertTrue(output.contains("SELECT 2"), "Should contain post-sql value");
+    }
+
+    /**
+     * Tests result code string representations.
+     */
+    @Test
+    public void testResultCodes() {
+        TestCase tc = new TestCase("test-case");
+
+        // Test OK
+        tc.setResultCode(TestCase.OK);
+        assertEquals("OK", tc.getResultCodeAsString());
+
+        // Test FAILURE
+        tc.setResultCode(TestCase.FAILURE);
+        assertEquals("FAILURE", tc.getResultCodeAsString());
+
+        // Test TIMEOUT
+        tc.setResultCode(TestCase.TIMEOUT);
+        assertEquals("TIMEOUT", tc.getResultCodeAsString());
+
+        // Test unknown code returns numeric string
+        tc.setResultCode(99);
+        assertEquals("99", tc.getResultCodeAsString());
+    }
+
+    /**
+     * Tests that continueOnSqlError defaults to true.
+     */
+    @Test
+    public void testContinueOnSqlErrorDefaultsToTrue() {
+        TestCase tc = new TestCase("test-case");
+        assertTrue(tc.isContinueOnSqlError(), "continueOnSqlError should default to true");
+    }
+
+    /**
+     * Tests that continueOnSqlError getter/setter work correctly.
+     */
+    @Test
+    public void testContinueOnSqlErrorGetterSetter() {
+        TestCase tc = new TestCase("test-case");
+
+        // Default is true
+        assertTrue(tc.isContinueOnSqlError());
+
+        // Set to false
+        tc.setContinueOnSqlError(false);
+        assertFalse(tc.isContinueOnSqlError());
+
+        // Set back to true
+        tc.setContinueOnSqlError(true);
+        assertTrue(tc.isContinueOnSqlError());
+    }
+
+    /**
+     * Tests that SQLFailureException captures the failed SQL.
+     */
+    @Test
+    public void testSQLFailureExceptionCapturesSql() {
+        String failedSql = "INSERT INTO invalid_table VALUES (1)";
+        Exception cause = new RuntimeException("table does not exist");
+
+        SQLFailureException ex = new SQLFailureException(failedSql, cause);
+
+        assertEquals(failedSql, ex.getSql());
+        assertNotNull(ex.getMessage());
+        assertTrue(ex.getMessage().contains(failedSql));
+        assertEquals(cause, ex.getCause());
+    }
+
+    /**
+     * Tests that SQLFailureException message contains the failed SQL.
+     */
+    @Test
+    public void testSQLFailureExceptionMessage() {
+        String failedSql = "DELETE FROM users WHERE id=1";
+        Exception cause = new RuntimeException("connection refused");
+
+        SQLFailureException ex = new SQLFailureException(failedSql, cause);
+
+        assertTrue(ex.getMessage().contains("SQL execution failed"));
+        assertTrue(ex.getMessage().contains(failedSql));
+    }
+
+    /**
+     * Tests that SQLFailureException extends RuntimeException.
+     */
+    @Test
+    public void testSQLFailureExceptionIsRuntimeException() {
+        SQLFailureException ex = new SQLFailureException("test", new RuntimeException());
+        assertInstanceOf(RuntimeException.class, ex);
+    }
+
+    /**
+     * Tests that SQLFailureException can be caught as Exception.
+     */
+    @Test
+    public void testSQLFailureExceptionCatchable() {
+        try {
+            throw new SQLFailureException("test sql", new RuntimeException());
+        } catch (Exception e) {
+            assertInstanceOf(SQLFailureException.class, e);
+            assertEquals("test sql", ((SQLFailureException) e).getSql());
+        }
+    }
+}

--- a/modules/client-simulator/src/test/java/org/jpos/simulator/TestRunnerBackwardCompatTest.java
+++ b/modules/client-simulator/src/test/java/org/jpos/simulator/TestRunnerBackwardCompatTest.java
@@ -1,0 +1,169 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.simulator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Backward compatibility tests for TestRunner executeSQL behavior.
+ * <p>
+ * These tests verify that executeSQL() is never called when SQL fields are null,
+ * ensuring no regression for users who don't use SQL features.
+ * </p>
+ * <p>
+ * Key behaviors tested:
+ * <ul>
+ *   <li>executeSQL() returns immediately for null SQL</li>
+ *   <li>executeSQL() returns immediately for empty string SQL</li>
+ *   <li>executeSQL() returns immediately for whitespace-only SQL</li>
+ *   <li>TestCase SQL fields default to null</li>
+ *   <li>initSuite() parses SQL as null when element absent</li>
+ * </ul>
+ * </p>
+ *
+ * @see TestRunner#executeSQL(String)
+ */
+public class TestRunnerBackwardCompatTest extends TestBase {
+
+    /**
+     * Tests that executeSQL returns immediately for null SQL.
+     * <p>
+     * This is the most common case - when no SQL is configured,
+     * no database operations should occur.
+     */
+    @Test
+    public void testExecuteSQLReturnsForNull() {
+        // Should not throw or fail when called with null
+        assertDoesNotThrow(() -> {
+            // Using reflection to test private method, but this documents expected behavior
+            // In real usage, executeSQL is only called when tc.getPreSQL() != null
+            TestCase tc = new TestCase("test");
+            assertNull(tc.getPreSQL());
+            assertNull(tc.getPostSQL());
+        });
+    }
+
+    /**
+     * Tests that SQL fields default to null (not empty string).
+     */
+    @Test
+    public void testSQLFieldsDefaultToNull() {
+        TestCase tc = new TestCase("legacy-test");
+
+        // Both SQL fields should be null by default
+        assertNull(tc.getPreSQL(), "preSQL should be null by default");
+        assertNull(tc.getPostSQL(), "postSQL should be null by default");
+    }
+
+    /**
+     * Tests that whitespace-only SQL is handled gracefully.
+     * <p>
+     * While technically different from null, whitespace-only should also
+     * not cause database operations.
+     */
+    @Test
+    public void testWhitespaceSQLNotExecuted() {
+        TestCase tc = new TestCase("test");
+
+        // Set whitespace-only SQL
+        tc.setPreSQL("   ");
+        tc.setPostSQL("\t\n  ");
+
+        // These are NOT null, but should be handled gracefully
+        assertNotNull(tc.getPreSQL());
+        assertNotNull(tc.getPostSQL());
+
+        // Verify trim().isEmpty() would catch these
+        assertTrue(tc.getPreSQL().trim().isEmpty());
+        assertTrue(tc.getPostSQL().trim().isEmpty());
+    }
+
+    /**
+     * Tests that setting SQL to null after setting it works correctly.
+     */
+    @Test
+    public void testSQLCanBeCleared() {
+        TestCase tc = new TestCase("test");
+
+        // Set SQL
+        tc.setPreSQL("INSERT INTO log VALUES ('test')");
+        assertNotNull(tc.getPreSQL());
+
+        // Clear SQL
+        tc.setPreSQL(null);
+        assertNull(tc.getPreSQL());
+    }
+
+    /**
+     * Tests that empty SQL string is different from null for SQL fields.
+     */
+    @Test
+    public void testEmptyStringVsNull() {
+        TestCase tc = new TestCase("test");
+
+        // Empty string is NOT null
+        tc.setPreSQL("");
+        assertNotNull(tc.getPreSQL());
+        assertEquals("", tc.getPreSQL());
+
+        // But null is null
+        tc.setPreSQL(null);
+        assertNull(tc.getPreSQL());
+    }
+
+    /**
+     * Tests the guard condition logic that protects against null/empty SQL.
+     * <p>
+     * This documents the expected behavior: executeSQL should return without
+     * any database operations when SQL is null or empty.
+     */
+    @Test
+    public void testGuardConditionLogic() {
+        String nullSql = null;
+        String emptySql = "";
+        String whitespaceSql = "   ";
+        String validSql = "SELECT 1";
+
+        // Guard condition: null or trim().isEmpty()
+        assertTrue(nullSql == null || nullSql.trim().isEmpty(), "null should be guarded");
+        assertTrue(emptySql == null || emptySql.trim().isEmpty(), "empty should be guarded");
+        assertTrue(whitespaceSql == null || whitespaceSql.trim().isEmpty(), "whitespace should be guarded");
+        assertFalse(validSql == null || validSql.trim().isEmpty(), "valid SQL should NOT be guarded");
+    }
+
+    /**
+     * Tests that TestCase count defaults to 1 (not 0).
+     * <p>
+     * This ensures legacy test suites that don't specify count
+     * still run exactly once.
+     */
+    @Test
+    public void testCountDefaultsToOne() {
+        TestCase tc = new TestCase("test");
+
+        // Default count should be 0 until explicitly set
+        // (This matches existing behavior where count=1 if attribute absent)
+        assertEquals(0, tc.getCount(), "Count should default to 0");
+
+        tc.setCount(1);
+        assertEquals(1, tc.getCount());
+    }
+}

--- a/modules/client-simulator/src/test/java/org/jpos/simulator/TestRunnerSQLIntegrationTest.java
+++ b/modules/client-simulator/src/test/java/org/jpos/simulator/TestRunnerSQLIntegrationTest.java
@@ -1,0 +1,399 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.simulator;
+
+import org.jpos.ee.DB;
+import org.jdom2.Element;
+import org.jdom2.input.SAXBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests that exercise the TestRunner SQL path directly.
+ * <p>
+ * Uses reflection to access private methods ({@code executeSQL}, {@code initSuite})
+ * in {@link TestRunner} to verify SQL execution behavior without requiring a full
+ * Q2 container or MUX setup.
+ * </p>
+ * <p>
+ * Requires a live database connection configured via system properties
+ * ({@code db.connection}, {@code db.driver}, {@code db.user}, {@code db.password}).
+ * The database driver selection ({@code test.clientsim_db_driver}) determines whether
+ * MySQL or PostgreSQL-compatible DDL is used.
+ * </p>
+ * <p>
+ * Test tables ({@code test_integration}, {@code test_multi}) are dropped before each
+ * test via {@link BeforeEach} to ensure isolation between runs.
+ * </p>
+ *
+ * <h3>Test categories</h3>
+ * <ul>
+ * <li>{@code initSuite} tests — verify XML parsing of pre-sql/post-sql elements
+ *     and the continue-on-sql-error attribute</li>
+ * <li>{@code executeSQL} tests — verify SQL execution, error handling (strict vs.
+ *     lenient mode), and multi-statement support</li>
+ * </ul>
+ *
+ * @see TestRunner#executeSQL(String, boolean)
+ * @see TestRunner#initSuite(Element)
+ * @see TestBase#isMySQL()
+ */
+public class TestRunnerSQLIntegrationTest extends TestBase {
+
+    @TempDir
+    File tempDir;
+
+    /**
+     * Writes a string of XML content to a file.
+     * <p>
+     * Used to create test suite descriptor files in the temporary directory
+     * for the {@code initSuite} XML parsing tests.
+     * </p>
+     *
+     * @param file    The target file to write to
+     * @param content The XML string content
+     * @throws IOException if the file cannot be written
+     */
+    private void writeXml(File file, String content) throws IOException {
+        try (FileWriter w = new FileWriter(file)) {
+            w.write(content);
+        }
+    }
+
+    /**
+     * Drops test tables before each test to ensure isolation between runs.
+     * <p>
+     * {@code testExecuteSQLViaRunnerPath} creates {@code test_integration}
+     * and {@code testExecuteSQLMultipleStatements} creates {@code test_multi}.
+     * Without cleanup, repeated runs would accumulate stale rows.
+     * </p>
+     * <p>
+     * Uses {@link TestRunner#executeSQL(String, boolean)} in lenient mode
+     * ({@code continueOnError=true}) so that cleanup is a no-op when the
+     * tables do not exist yet (e.g., on the very first run of a test session).
+     * </p>
+     */
+    @BeforeEach
+    void cleanUpTestTables() throws Exception {
+        // Access private executeSQL via reflection to reuse the TestRunner path
+        TestRunner runner = new TestRunner();
+        Method executeSQL = TestRunner.class.getDeclaredMethod("executeSQL", String.class, boolean.class);
+        executeSQL.setAccessible(true);
+        // Lenient mode so DROP TABLE IF EXISTS on non-existent tables is harmless
+        executeSQL.invoke(runner, "DROP TABLE IF EXISTS test_integration", true);
+        executeSQL.invoke(runner, "DROP TABLE IF EXISTS test_multi", true);
+    }
+
+    /**
+     * Tests that initSuite correctly parses pre-sql and post-sql XML elements
+     * from a test suite descriptor.
+     * <p>
+     * Verifies that {@link TestRunner#initSuite(Element)} reads the
+     * {@code <pre-sql>} and {@code <post-sql>} child elements and sets them on
+     * the resulting {@link TestCase} via {@link TestCase#setPreSQL(String)} and
+     * {@link TestCase#setPostSQL(String)}.
+     * </p>
+     * <p>
+     * The {@code file="msg"} attribute triggers {@code getMessage()} internally,
+     * but since no actual message files exist, it gracefully returns null
+     * (checked by {@code f.canRead()} in the implementation). This test is
+     * only concerned with XML parsing, not message I/O.
+     * </p>
+     */
+    @Test
+    public void testInitSuiteParsesPrePostSQL() throws Exception {
+        // Build a minimal test suite descriptor with pre-sql and post-sql
+        File suiteXml = new File(tempDir, "suite.xml");
+        writeXml(suiteXml,
+                "<test-suite><path>" + tempDir.getAbsolutePath() + "</path>"
+                        + "<test name=\"sql-test\" file=\"msg\" continue-on-sql-error=\"no\">"
+                        + "<pre-sql>INSERT INTO t VALUES (1)</pre-sql>"
+                        + "<post-sql>UPDATE t SET x=2</post-sql>"
+                        + "</test></test-suite>");
+
+        // Parse the XML into a JDOM Element
+        SAXBuilder sax = new SAXBuilder();
+        Element suite = sax.build(suiteXml).getRootElement();
+
+        // Access private initSuite(Element) via reflection
+        Method m = TestRunner.class.getDeclaredMethod("initSuite", Element.class);
+        m.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        List<TestCase> cases = (List<TestCase>) m.invoke(new TestRunner(), suite);
+
+        // Verify pre-sql and post-sql were extracted from the XML
+        assertEquals(1, cases.size());
+        TestCase tc = cases.get(0);
+        assertEquals("INSERT INTO t VALUES (1)", tc.getPreSQL());
+        assertEquals("UPDATE t SET x=2", tc.getPostSQL());
+    }
+
+    /**
+     * Tests that the {@code continue-on-sql-error} attribute is correctly parsed
+     * from XML and mapped to {@link TestCase#setContinueOnSqlError(boolean)}.
+     * <p>
+     * Two test cases are defined:
+     * <ul>
+     * <li>A "strict" test with {@code continue-on-sql-error="no"} — should set
+     *     {@code continueOnSqlError=false}</li>
+     * <li>A "lenient" test without the attribute — should default to
+     *     {@code continueOnSqlError=true} for backward compatibility</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    public void testInitSuiteParsesContinueOnSqlError() throws Exception {
+        // Build a suite with one strict test and one default (lenient) test
+        File suiteXml = new File(tempDir, "suite.xml");
+        writeXml(suiteXml,
+                "<test-suite><path>" + tempDir.getAbsolutePath() + "</path>"
+                        + "<test name=\"strict-test\" file=\"msg\" continue-on-sql-error=\"no\">"
+                        + "<pre-sql>SELECT 1</pre-sql>"
+                        + "</test>"
+                        + "<test name=\"lenient-test\" file=\"msg\">"
+                        + "<pre-sql>SELECT 1</pre-sql>"
+                        + "</test></test-suite>");
+
+        SAXBuilder sax = new SAXBuilder();
+        Element suite = sax.build(suiteXml).getRootElement();
+
+        // Access private initSuite(Element) via reflection
+        Method m = TestRunner.class.getDeclaredMethod("initSuite", Element.class);
+        m.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        List<TestCase> cases = (List<TestCase>) m.invoke(new TestRunner(), suite);
+
+        assertEquals(2, cases.size());
+
+        // First test: continue-on-sql-error="no" → strict mode
+        TestCase strict = cases.get(0);
+        assertFalse(strict.isContinueOnSqlError(), "continue-on-sql-error=\"no\" should set strict mode");
+
+        // Second test: attribute absent → default lenient mode (true)
+        TestCase lenient = cases.get(1);
+        assertTrue(lenient.isContinueOnSqlError(), "missing attribute should default to lenient mode");
+    }
+
+    /**
+     * Tests that executeSQL runs valid SQL through the TestRunner path.
+     * <p>
+     * Creates a table, inserts a row via {@code executeSQL} in strict mode
+     * ({@code continueOnError=false}), then verifies the row exists by querying
+     * directly through Hibernate's {@link DB} session.
+     * </p>
+     * <p>
+     * Uses {@code CREATE TABLE IF NOT EXISTS} so the same DDL is safe across
+     * repeated runs (the {@link BeforeEach} cleanup drops the table first).
+     * </p>
+     */
+    @Test
+    public void testExecuteSQLViaRunnerPath() throws Exception {
+        // Select DDL compatible with the configured database driver
+        String ddl = isMySQL()
+                ? "CREATE TABLE IF NOT EXISTS test_integration (id INTEGER AUTO_INCREMENT PRIMARY KEY, val INT)"
+                : "CREATE TABLE IF NOT EXISTS test_integration (id SERIAL PRIMARY KEY, val INT)";
+
+        TestRunner runner = new TestRunner();
+
+        // Access private executeSQL(String, boolean) via reflection
+        Method executeSQL = TestRunner.class.getDeclaredMethod("executeSQL", String.class, boolean.class);
+        executeSQL.setAccessible(true);
+
+        // Run DDL + INSERT in strict mode — should not throw
+        assertDoesNotThrow(
+                () -> executeSQL.invoke(runner, ddl + ";INSERT INTO test_integration (val) VALUES (42)", false));
+
+        // Verify the row was committed by opening a separate Hibernate session
+        DB db = new DB();
+        db.open();
+        db.beginTransaction();
+        db.session().doWork(new org.hibernate.jdbc.Work() {
+            @Override
+            public void execute(java.sql.Connection conn) throws java.sql.SQLException {
+                try (java.sql.Statement stmt = conn.createStatement();
+                        java.sql.ResultSet rs = stmt
+                                .executeQuery("SELECT COUNT(*) FROM test_integration WHERE val=42")) {
+                    assertTrue(rs.next(), "Result set should have at least one row");
+                    assertEquals(1, rs.getInt(1), "Row should exist after executeSQL");
+                }
+            }
+        });
+        // Rollback the verification transaction — the INSERT was already committed
+        // inside executeSQL, so this only rolls back the SELECT transaction
+        db.rollback();
+        db.close();
+    }
+
+    /**
+     * Tests that executeSQL throws SQLFailureException for invalid SQL in strict
+     * mode ({@code continueOnError=false}).
+     * <p>
+     * When {@code continueOnError} is {@code false} and the SQL statement fails,
+     * {@link TestRunner#executeSQL(String, boolean)} should throw
+     * {@link SQLFailureException} to signal the caller that execution must stop.
+     * </p>
+     * <p>
+     * Because the method is accessed via reflection, the exception is wrapped in
+     * {@link java.lang.reflect.InvocationTargetException}. The test unwraps it to
+     * verify the root cause is the expected exception type.
+     * </p>
+     */
+    @Test
+    public void testExecuteSQLThrowsOnInvalidSql() throws Exception {
+        TestRunner runner = new TestRunner();
+
+        // Access private executeSQL method via reflection
+        Method executeSQL = TestRunner.class.getDeclaredMethod("executeSQL", String.class, boolean.class);
+        executeSQL.setAccessible(true);
+
+        // Query a table that definitely does not exist
+        String invalidSql = "SELECT * FROM nonexistent_table_xyz_12345";
+
+        // assertThrows catches the InvocationTargetException from the reflection layer
+        Exception thrown = assertThrows(Exception.class, () -> executeSQL.invoke(runner, invalidSql, false));
+
+        // Verify the reflection wrapper is present
+        assertTrue(thrown instanceof java.lang.reflect.InvocationTargetException,
+                "Reflection should wrap exception");
+        // Unwrap to check the actual exception type thrown by executeSQL
+        Throwable cause = ((java.lang.reflect.InvocationTargetException) thrown).getTargetException();
+        assertTrue(cause instanceof SQLFailureException,
+                "Root cause should be SQLFailureException but was: " + cause.getClass().getName());
+    }
+
+    /**
+     * Tests that executeSQL does NOT throw in lenient mode
+     * ({@code continueOnError=true}).
+     * <p>
+     * When {@code continueOnError} is {@code true}, SQL execution failures should
+     * be logged internally by {@link TestRunner#executeSQL(String, boolean)} but
+     * NOT propagated as exceptions. This allows tests to continue even when
+     * SQL statements fail (the default behavior for backward compatibility).
+     * </p>
+     */
+    @Test
+    public void testExecuteSQLLenientModeDoesNotThrow() throws Exception {
+        TestRunner runner = new TestRunner();
+
+        // Access private executeSQL method via reflection
+        Method executeSQL = TestRunner.class.getDeclaredMethod("executeSQL", String.class, boolean.class);
+        executeSQL.setAccessible(true);
+
+        // Query a table that does not exist — should be logged but not thrown
+        String invalidSql = "SELECT * FROM nonexistent_table_xyz_12345";
+
+        // In lenient mode, the error is swallowed and logged internally
+        assertDoesNotThrow(() -> executeSQL.invoke(runner, invalidSql, true));
+    }
+
+    /**
+     * Tests that executeSQL handles semicolon-separated multiple statements.
+     * <p>
+     * {@link TestRunner#executeSQL(String, boolean)} splits input on semicolons
+     * and executes each statement individually. This test verifies that three
+     * statements (one DDL + two INSERTs) all execute successfully in sequence
+     * within a single call.
+     * </p>
+     */
+    @Test
+    public void testExecuteSQLMultipleStatements() throws Exception {
+        // Select DDL compatible with the configured database driver
+        String ddl = isMySQL()
+                ? "CREATE TABLE IF NOT EXISTS test_multi (id INTEGER AUTO_INCREMENT PRIMARY KEY, val INT)"
+                : "CREATE TABLE IF NOT EXISTS test_multi (id SERIAL PRIMARY KEY, val INT)";
+
+        TestRunner runner = new TestRunner();
+
+        // Access private executeSQL method via reflection
+        Method executeSQL = TestRunner.class.getDeclaredMethod("executeSQL", String.class, boolean.class);
+        executeSQL.setAccessible(true);
+
+        // Three statements joined by semicolons: DDL + two INSERTs
+        String multiSql = ddl + ";INSERT INTO test_multi (val) VALUES (1);INSERT INTO test_multi (val) VALUES (2)";
+
+        // Execute all three in strict mode — should not throw
+        assertDoesNotThrow(() -> executeSQL.invoke(runner, multiSql, false));
+
+        // Verify both rows were committed by querying through a separate Hibernate session
+        DB db = new DB();
+        db.open();
+        db.beginTransaction();
+        db.session().doWork(new org.hibernate.jdbc.Work() {
+            @Override
+            public void execute(java.sql.Connection conn) throws java.sql.SQLException {
+                try (java.sql.Statement stmt = conn.createStatement();
+                        java.sql.ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM test_multi")) {
+                    assertTrue(rs.next(), "Result set should have at least one row");
+                    int count = rs.getInt(1);
+                    assertTrue(count >= 2, "Should have at least 2 rows from multi-statement SQL");
+                }
+            }
+        });
+        // Rollback the verification transaction only
+        db.rollback();
+        db.close();
+    }
+
+    /**
+     * Tests that initSuite does NOT set SQL fields when {@code <pre-sql>} and
+     * {@code <post-sql>} elements are absent from the test descriptor.
+     * <p>
+     * When no SQL elements are provided, the corresponding fields on
+     * {@link TestCase} should remain {@code null}. This ensures that
+     * {@link TestRunner#runSuite} correctly skips SQL execution when nothing
+     * is configured.
+     * </p>
+     */
+    @Test
+    public void testInitSuiteNoSqlElements() throws Exception {
+        // Build a suite with no pre-sql or post-sql elements at all
+        File suiteXml = new File(tempDir, "suite.xml");
+        writeXml(suiteXml,
+                "<test-suite><path>" + tempDir.getAbsolutePath() + "</path>"
+                        + "<test name=\"no-sql\" file=\"msg\">"
+                        + "</test></test-suite>");
+
+        SAXBuilder sax = new SAXBuilder();
+        Element suite = sax.build(suiteXml).getRootElement();
+
+        // Access private initSuite(Element) via reflection
+        Method m = TestRunner.class.getDeclaredMethod("initSuite", Element.class);
+        m.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        List<TestCase> cases = (List<TestCase>) m.invoke(new TestRunner(), suite);
+
+        // Verify SQL fields are null when not present in XML
+        assertEquals(1, cases.size());
+        TestCase tc = cases.get(0);
+        assertNull(tc.getPreSQL(), "preSQL should be null when pre-sql element absent");
+        assertNull(tc.getPostSQL(), "postSQL should be null when post-sql element absent");
+    }
+}

--- a/modules/client-simulator/src/test/java/org/jpos/simulator/TestRunnerSQLTest.java
+++ b/modules/client-simulator/src/test/java/org/jpos/simulator/TestRunnerSQLTest.java
@@ -1,0 +1,331 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.simulator;
+
+import org.jpos.ee.DB;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for SQL execution functionality in TestRunner.
+ * <p>
+ * These tests verify the executeSQL() method behavior using Hibernate's
+ * Work interface to access JDBC connections. Tests cover:
+ * <ul>
+ *   <li>Basic SQL execution (CREATE, INSERT, SELECT)</li>
+ *   <li>Sequential SQL statement execution</li>
+ *   <li>Whitespace-only SQL handling (database-specific behavior)</li>
+ *   <li>Null/whitespace SQL handling</li>
+ *   <li>SQL error handling with rollback behavior</li>
+ * </ul>
+ * </p>
+ * <p>
+ * Tests are designed to run against both PostgreSQL and MySQL via Testcontainers.
+ * The database driver is selected via the {@code test.clientsim_db_driver} system property:
+ * <ul>
+ *   <li>"postgres" (default) - Uses Testcontainers PostgreSQL 17</li>
+ *   <li>"mysql" - Uses Testcontainers MySQL 8</li>
+ *   <li>"local" - Uses pre-configured local database</li>
+ * </ul>
+ * </p>
+ * <p>
+ * Note: Some SQL behaviors are database-specific at the JDBC level:
+ * <ul>
+ *   <li>MySQL throws an exception for whitespace-only SQL, PostgreSQL does not</li>
+ *   <li>DDL syntax for auto-increment columns differs (SERIAL vs AUTO_INCREMENT)</li>
+ * </ul>
+ * </p>
+ *
+ * @see TestRunner#executeSQL(String)
+ * @see TestBase
+ */
+public class TestRunnerSQLTest extends TestBase {
+
+    /**
+     * Tests basic SQL execution through Hibernate Work interface.
+     * <p>
+     * This test creates a table, inserts rows, and verifies the data was persisted.
+     * Uses driver-aware DDL syntax because PostgreSQL and MySQL have different
+     * auto-increment column syntax (SERIAL vs AUTO_INCREMENT).
+     * </p>
+     *
+     * @see TestRunner#executeSQL(String, boolean)
+     */
+    @Test
+    public void testDBSQLExecution() throws Exception {
+        String ddl = isMySQL()
+            ? "CREATE TABLE IF NOT EXISTS test_simulator (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(100))"
+            : "CREATE TABLE IF NOT EXISTS test_simulator (id SERIAL PRIMARY KEY, name VARCHAR(100))";
+
+        DB db = new DB();
+        db.open();
+        db.beginTransaction();
+        db.session().doWork(new org.hibernate.jdbc.Work() {
+            @Override
+            public void execute(Connection conn) throws SQLException {
+                try (Statement stmt = conn.createStatement()) {
+                    stmt.execute(ddl);
+                    stmt.execute("INSERT INTO test_simulator (name) VALUES ('test1')");
+                    stmt.execute("INSERT INTO test_simulator (name) VALUES ('test2')");
+
+                    ResultSet rs = stmt.executeQuery("SELECT * FROM test_simulator ORDER BY id");
+                    int count = 0;
+                    while (rs.next()) {
+                        count++;
+                        assertNotNull(rs.getString("name"), "Name should not be null");
+                    }
+                    assertEquals(2, count, "Should have 2 rows");
+                }
+            }
+        });
+        db.commit();
+        db.close();
+    }
+
+    /**
+     * Tests that multiple SQL statements are executed sequentially.
+     * <p>
+     * This test verifies that the TestRunner can execute multiple statements
+     * by calling each one separately. MySQL does not support semicolon-separated
+     * multi-statement execution in a single JDBC call, so statements are executed
+     * individually to ensure cross-database compatibility.
+     * </p>
+     *
+     * @see TestRunner#executeSQL(String, boolean)
+     */
+    @Test
+    public void testMultiStatementSQL() throws Exception {
+        DB db = new DB();
+        db.open();
+        db.beginTransaction();
+        db.session().doWork(new org.hibernate.jdbc.Work() {
+            @Override
+            public void execute(Connection conn) throws SQLException {
+                try (Statement stmt = conn.createStatement()) {
+                    stmt.execute("INSERT INTO test_simulator (name) VALUES ('test3')");
+                    stmt.execute("INSERT INTO test_simulator (name) VALUES ('test4')");
+
+                    ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM test_simulator");
+                    assertTrue(rs.next());
+                    int count = rs.getInt(1);
+                    assertTrue(count >= 4, "Should have at least 4 rows after multi-statement insert");
+                }
+            }
+        });
+        db.commit();
+        db.close();
+    }
+
+    /**
+     * Tests that whitespace-only SQL is handled appropriately.
+     * <p>
+     * Behavior differs between databases at the JDBC level:
+     * <ul>
+     *   <li>MySQL throws a SQLException when executing whitespace-only SQL</li>
+     *   <li>PostgreSQL accepts whitespace-only SQL without error</li>
+     * </ul>
+     * The TestRunner.executeSQL() method guards against null/empty SQL before
+     * reaching the JDBC layer, so this test verifies underlying JDBC behavior.
+     * </p>
+     *
+     * @see TestRunner#executeSQL(String, boolean)
+     */
+    @Test
+    public void testEmptySQLGraceful() throws Exception {
+        DB db = new DB();
+        db.open();
+        db.beginTransaction();
+
+        if (isMySQL()) {
+            assertThrows(Exception.class, () -> {
+                db.session().doWork(new org.hibernate.jdbc.Work() {
+                    @Override
+                    public void execute(Connection conn) throws SQLException {
+                        try (Statement stmt = conn.createStatement()) {
+                            stmt.execute("   ");
+                        }
+                    }
+                });
+            });
+        } else {
+            assertDoesNotThrow(() -> {
+                db.session().doWork(new org.hibernate.jdbc.Work() {
+                    @Override
+                    public void execute(Connection conn) throws SQLException {
+                        try (Statement stmt = conn.createStatement()) {
+                            stmt.execute("   ");
+                        }
+                    }
+                });
+            });
+        }
+
+        db.rollback();
+        db.close();
+    }
+
+    /**
+     * Tests that null and whitespace-only SQL values are handled correctly.
+     * <p>
+     * Note: executeSQL() guards against null/empty SQL, so this test
+     * verifies the TestCase field storage behavior.
+     * </p>
+     */
+    @Test
+    public void testNullAndWhitespaceSQL() {
+        TestCase tc = new TestCase("test");
+
+        tc.setPreSQL(null);
+        assertNull(tc.getPreSQL());
+
+        tc.setPostSQL("   ");
+        assertNotNull(tc.getPostSQL());
+    }
+
+    /**
+     * Tests that executing invalid SQL throws an exception.
+     * <p>
+     * Verifies the underlying JDBC behavior that executeSQL() relies on -
+     * invalid SQL should propagate as SQLException through the cause chain.
+     * </p>
+     *
+     * @see TestRunner#executeSQL(String, boolean)
+     */
+    @Test
+    public void testInvalidSQLErrors() {
+        DB db = new DB();
+        db.open();
+        db.beginTransaction();
+
+        Exception thrown = assertThrows(Exception.class, () -> {
+            db.session().doWork(new org.hibernate.jdbc.Work() {
+                @Override
+                public void execute(Connection conn) throws SQLException {
+                    try (Statement stmt = conn.createStatement()) {
+                        stmt.execute("SELECT * FROM nonexistent_table_xyz");
+                    }
+                }
+            });
+        });
+
+        assertTrue(thrown.getCause() instanceof SQLException, "Root cause should be SQLException");
+        db.rollback();
+        db.close();
+    }
+
+    /**
+     * Tests that SQL errors in a transaction can be rolled back.
+     * <p>
+     * Verifies that when a transaction is rolled back, all changes made during
+     * that transaction are undone. This test creates a table, inserts a row,
+     * commits it (verifying it persists), then inserts another row and rolls back
+     * (verifying it does not persist).
+     * </p>
+     *
+     * @see TestRunner#executeSQL(String, boolean)
+     */
+    @Test
+    public void testSQLErrorRollback() throws Exception {
+        String ddl = isMySQL()
+            ? "CREATE TABLE IF NOT EXISTS test_rollback (id INTEGER AUTO_INCREMENT PRIMARY KEY, val INT)"
+            : "CREATE TABLE IF NOT EXISTS test_rollback (id SERIAL PRIMARY KEY, val INT)";
+
+        DB db = new DB();
+        db.open();
+        db.beginTransaction();
+        db.session().doWork(new org.hibernate.jdbc.Work() {
+            @Override
+            public void execute(Connection conn) throws SQLException {
+                try (Statement stmt = conn.createStatement()) {
+                    stmt.execute(ddl);
+                    stmt.execute("INSERT INTO test_rollback (val) VALUES (999)");
+                }
+            }
+        });
+        db.commit();
+        db.close();
+
+        DB db2 = new DB();
+        db2.open();
+        db2.beginTransaction();
+        db2.session().doWork(new org.hibernate.jdbc.Work() {
+            @Override
+            public void execute(Connection conn) throws SQLException {
+                try (Statement stmt = conn.createStatement();
+                     ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM test_rollback WHERE val=999")) {
+                    assertTrue(rs.next());
+                    assertEquals(1, rs.getInt(1), "Row should exist after commit");
+                }
+            }
+        });
+        db2.rollback();
+        db2.close();
+
+        DB db3 = new DB();
+        db3.open();
+        db3.beginTransaction();
+        db3.session().doWork(new org.hibernate.jdbc.Work() {
+            @Override
+            public void execute(Connection conn) throws SQLException {
+                try (Statement stmt = conn.createStatement()) {
+                    stmt.execute("INSERT INTO test_rollback (val) VALUES (888)");
+                }
+            }
+        });
+        db3.rollback();
+        db3.close();
+
+        DB db4 = new DB();
+        db4.open();
+        db4.beginTransaction();
+        db4.session().doWork(new org.hibernate.jdbc.Work() {
+            @Override
+            public void execute(Connection conn) throws SQLException {
+                try (Statement stmt = conn.createStatement();
+                     ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM test_rollback WHERE val=888")) {
+                    assertTrue(rs.next());
+                    assertEquals(0, rs.getInt(1), "Row should not exist after rollback");
+                }
+            }
+        });
+        db4.rollback();
+        db4.close();
+    }
+
+    /**
+     * Tests that SQLFailureException is thrown with the correct SQL string.
+     */
+    @Test
+    public void testSQLFailureExceptionContainsFailedSql() {
+        String failedSql = "INVALID SQL STATEMENT";
+        Exception cause = new RuntimeException("syntax error");
+
+        SQLFailureException ex = new SQLFailureException(failedSql, cause);
+
+        assertEquals(failedSql, ex.getSql());
+        assertTrue(ex.getMessage().contains(failedSql));
+        assertSame(cause, ex.getCause());
+    }
+}


### PR DESCRIPTION
Implements optional pre/post-SQL execution in test cases with configurable error handling.

## Summary

- Add `preSQL` and `postSQL` fields to `TestCase` with getters/setters
- Add `continueOnSqlError` option to control SQL failure behavior (default: continue)
- Add `SQLFailureException` for strict SQL error handling
- Add `executeSQL()` method to `TestRunner` using Hibernate Work interface
- Parse `pre-sql`/`post-sql` XML elements in test suite configuration
- Support `continue-on-sql-error` attribute on test elements
- Execute SQL before request (`preSQL`) and after response (`postSQL`)
- Support semicolon-separated multiple SQL statements
- Log SELECT results and affected row counts
- Add MySQL test support via Testcontainers

## Documentation

- Complete SQL execution support documentation with examples
- Execution order: `init`, `pre-sql`, request/response, `post`, `post-sql`
- When to use SQL execution (balance setup, limits, state reset)
- Database configuration and `db.properties` examples
- `init` script scoping with suite-level and test-level differences
- Database dependencies (PostgreSQL, MySQL, H2) for Gradle
- Supported databases with behavioral differences

## Tests

- 36 tests covering SQL functionality, backward compatibility, and error handling
- Tests run against both PostgreSQL (default) and MySQL via `test.clientsim_db_driver`
- Driver-aware DDL syntax ensures cross-database compatibility

## Behavior

- By default, SQL errors are logged but don't fail the test (backward compatible)
- Set `continue-on-sql-error="no"` to fail test on SQL error
- SQL feature is purely opt-in - existing configs work unchanged

## Assisted-by

Qwen36