### PR TITLE
Fix TagsType null snapshot dirty checking

### DIFF
--- a/modules/dbsupport/build.gradle
+++ b/modules/dbsupport/build.gradle
@@ -11,5 +11,6 @@ dependencies {
     implementation libs.javaxCache
     implementation libs.ehCache
     implementation libs.jcache
+    testImplementation testlibs.bundles.junit
+    testRuntimeOnly testlibs.bundles.junit.platform
 }
-

--- a/modules/dbsupport/src/main/java/org/jpos/ee/usertype/TagsType.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/usertype/TagsType.java
@@ -48,7 +48,7 @@ public class TagsType implements UserType<Tags> {
 
     @Override
     public int hashCode(Tags x) {
-        return x.hashCode();
+        return x == null ? 0 : x.hashCode();
     }
 
     @Override
@@ -70,7 +70,7 @@ public class TagsType implements UserType<Tags> {
 
     @Override
     public Tags deepCopy(Tags value) {
-        return value != null ? new Tags(value.toString()) : new Tags();
+        return value == null ? null : new Tags(value.toString());
     }
 
     @Override
@@ -80,11 +80,11 @@ public class TagsType implements UserType<Tags> {
 
     @Override
     public Serializable disassemble(Tags value) {
-        return value.toString();
+        return value == null ? null : value.toString();
     }
 
     @Override
     public Tags assemble(Serializable cached, Object owner) {
-        return null;
+        return cached == null ? null : new Tags((String) cached);
     }
 }

--- a/modules/dbsupport/src/test/java/org/jpos/ee/usertype/TagsTypeTest.java
+++ b/modules/dbsupport/src/test/java/org/jpos/ee/usertype/TagsTypeTest.java
@@ -1,0 +1,72 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.ee.usertype;
+
+import org.jpos.util.Tags;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TagsTypeTest {
+    private final TagsType tagsType = new TagsType();
+
+    @Test
+    void deepCopyReturnsNullForNullValue() {
+        assertNull(tagsType.deepCopy(null));
+    }
+
+    @Test
+    void deepCopyReturnsSeparateEqualInstance() {
+        Tags tags = new Tags("a,b");
+
+        Tags copy = tagsType.deepCopy(tags);
+
+        assertEquals(tags, copy);
+        assertNotSame(tags, copy);
+    }
+
+    @Test
+    void equalsHandlesNullAndTagsValues() {
+        assertTrue(tagsType.equals(null, null));
+        assertFalse(tagsType.equals(null, new Tags()));
+        assertTrue(tagsType.equals(new Tags("a"), new Tags("a")));
+    }
+
+    @Test
+    void hashCodeReturnsZeroForNullValue() {
+        assertEquals(0, tagsType.hashCode(null));
+    }
+
+    @Test
+    void disassembleAndAssembleAreNullSafeAndSymmetric() {
+        assertNull(tagsType.disassemble(null));
+        assertNull(tagsType.assemble(null, null));
+
+        Tags tags = new Tags("a,b");
+        Serializable cached = tagsType.disassemble(tags);
+
+        assertEquals(tags, tagsType.assemble(cached, null));
+    }
+}


### PR DESCRIPTION
## Summary
- fix TagsType.deepCopy(null) to return null instead of an empty Tags instance
- make TagsType hashCode, disassemble, and assemble null-safe and symmetric
- add unit coverage for null snapshot handling and assemble/disassemble round trips
- add the dbsupport module JUnit test dependency required for the new unit test

## Why
Fix TagsType.deepCopy returning empty instead of null, which caused Hibernate to flag every Account with a NULL tags column as dirty and triggered acct-table updates that can deadlock under concurrent load.

## Testing
- ./gradlew :modules:dbsupport:test
- ./gradlew :modules:dbsupport:build