### PR TITLE
Bump dependency catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,9 +4,9 @@ commonsLang3 = "3.20.0"
 quartz = "2.5.2"
 slf4j = "2.0.18"
 jakartaBind = "4.0.5"
-logback = '1.5.32'
-jacksonDatabind = '2.21.3'
-netty = '4.2.14.Final'
+logback = '1.5.34'
+jacksonDatabind = '2.22.0'
+netty = '4.2.15.Final'
 freemarker = '2.3.34'
 jsonSchemaValidator = '2.2.14'
 guava = '33.6.0-jre'
@@ -26,10 +26,10 @@ jgroups = '5.5.5.Final'
 xmlBind = "4.0.5"
 javaxCache = '1.1.1'
 ehCache = '3.12.0'
-jetty = '12.1.9'
+jetty = '12.1.10'
 groovy = '4.0.32'
 kafka = '4.3.0'
-awssdk = '2.44.11'
+awssdk = '2.46.4'
 jakartaWsRs = '4.0.0'
 
 [libraries]


### PR DESCRIPTION
Summary:
- bump Logback from 1.5.32 to 1.5.34
- bump Jackson from 2.21.3 to 2.22.0
- bump Netty from 4.2.14.Final to 4.2.15.Final
- bump Jetty from 12.1.9 to 12.1.10
- bump AWS SDK from 2.44.11 to 2.46.4

Notes:
- left major-line upgrades out of this conservative pass, including Hibernate 7, Flyway 12, Groovy 5, and Hibernate Validator 8

Validation:
- ./gradlew help
- ./gradlew classes
- ./gradlew test
- git diff --check