### PR TITLE
fix(qrest-crud): correct getId cast, cache Validator, bound list limit

### DIFF
--- a/modules/qrest-crud/src/main/java/org/jpos/qrest/crud/participant/CRUD.java
+++ b/modules/qrest-crud/src/main/java/org/jpos/qrest/crud/participant/CRUD.java
@@ -122,6 +122,8 @@ public abstract class CRUD<T, I, O> implements TransactionParticipant, Configura
     private Class<T> managedORMClass;
     private Class<I> managedDTOInputClass;
     private Class<O> managedDTOOutputClass;
+    private static final Validator VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
+    private int maxResults;
 
     /**
      * Prepares this transaction participant for the requested HTTP method.
@@ -241,6 +243,7 @@ public abstract class CRUD<T, I, O> implements TransactionParticipant, Configura
             setIdMethodName = "set" + cfg.get("id", "Id");
             idType = getManagedORMClass().getMethod(getIdMethodName).getGenericReturnType().getTypeName();
             idClass = getIdClass();
+            maxResults = cfg.getInt("maxResults", 1000);
         } catch (NoSuchMethodException | ClassNotFoundException e) {
             throw new ConfigurationException(e);
         }
@@ -351,9 +354,7 @@ public abstract class CRUD<T, I, O> implements TransactionParticipant, Configura
                 ctx.put(TEMP_RESPONSE, new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST));
                 return null;
             }
-            ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-            Validator validator = factory.getValidator();
-            Set<ConstraintViolation<Object>> violations = validator.validate(entity);
+            Set<ConstraintViolation<Object>> violations = VALIDATOR.validate(entity);
             if (!violations.isEmpty()) {
                 for (ConstraintViolation<Object> violation : violations) {
                     ctx.log("Validation error: " + violation.getMessage());
@@ -622,11 +623,12 @@ public abstract class CRUD<T, I, O> implements TransactionParticipant, Configura
             Map<String, List<String>> queryParams = ctx.get(QUERYPARAMS);
             if (queryParams != null) {
                 Optional.ofNullable(queryParams.get("limit")).ifPresent(o -> {
-                    limit.set(Integer.parseInt(o.getFirst()));
+                    int requested = Math.max(1, parseIntOrDefault(o.getFirst(), limit.get()));
+                    limit.set(Math.min(requested, maxResults));
                     ctx.put("limit", limit.intValue());
                 });
                 Optional.ofNullable(queryParams.get("offset")).ifPresent(o -> {
-                    offset.set(Integer.parseInt(o.getFirst()));
+                    offset.set(Math.max(0, parseIntOrDefault(o.getFirst(), offset.get())));
                     ctx.put("offset", offset.intValue());
                 });
             }
@@ -923,9 +925,17 @@ public abstract class CRUD<T, I, O> implements TransactionParticipant, Configura
     protected Serializable getId(Object obj) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         Method method = obj.getClass().getMethod(getIdMethodName);
         Object id = method.invoke(obj, (Object[]) null);
-        if (id instanceof Number && ((long) id) == 0L)
+        if (id instanceof Number && ((Number) id).longValue() == 0L)
             id = null;
         return (Serializable) id;
+    }
+
+    private static int parseIntOrDefault(String s, int def) {
+        try {
+            return Integer.parseInt(s.trim());
+        } catch (NumberFormatException | NullPointerException e) {
+            return def;
+        }
     }
 
     /**


### PR DESCRIPTION
Three correctness/robustness fixes in the `CRUD` base participant (`modules/qrest-crud`).

### 1. `getId()` throws `ClassCastException` for `Integer`-typed entity ids
`((long) id)` on an `Object` holding an `Integer` compiles to a checkcast-to-`Long` plus unboxing, so it throws `ClassCastException: Integer cannot be cast to Long` at runtime. Reflection boxes even primitive `int` getters to `Integer`, so any entity whose id getter returns `int`/`Integer` (rather than `long`/`Long`) breaks on every POST/PUT/DELETE/GET-by-id, and the exception is swallowed into a generic abort. Fixed with `((Number) id).longValue() == 0L`.

### 2. `getAndValidateEntity()` rebuilds the Bean Validation factory on every request
`Validation.buildDefaultValidatorFactory()` is expensive and the returned `ValidatorFactory` (an `AutoCloseable`) was never closed. Replaced with a cached `static final Validator` (the `Validator` is thread-safe).

### 3. List GET `?limit` is unbounded and `?limit`/`?offset` crash on non-numeric input
`Integer.parseInt` threw on non-numeric input, and there was no server-side ceiling on `limit`, so a client could request an arbitrarily large page. Added a configurable `maxResults` ceiling (default **1000**, overridable per endpoint via `<property name="maxResults" value="..."/>`), clamped `limit` to `[1, maxResults]` and `offset` to `>= 0`, and made non-numeric input fall back to the existing defaults instead of throwing.

Default behavior is unchanged for callers requesting a sane page size; only requests above the ceiling are clamped.

### Verification
`./gradlew :modules:qrest-crud:compileJava` succeeds. The module has no existing test source set, so no unit tests were added.
