### PR TITLE
security: enforce WebSocket Origin in qrest

### DIFF
--- a/modules/qrest/src/main/java/org/jpos/qrest/RestServer.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/RestServer.java
@@ -82,6 +82,7 @@ public class RestServer extends QBeanSupport implements Runnable, XmlConfigurabl
     private CorsConfig defaultCorsConfig;
     private String websocketPath;
     private int maxWebSocketFrameSize;
+    private Set<String> websocketAllowedOrigins = Set.of();
     private Map<String,String> websocketRoutes = new LinkedHashMap<>();
     private Map<String, WebSocketHandler> websocketHandlers = new LinkedHashMap<>();
     private QRestMetrics metrics;
@@ -194,6 +195,10 @@ public class RestServer extends QBeanSupport implements Runnable, XmlConfigurabl
 
     QRestMetrics getMetrics() {
         return metrics;
+    }
+
+    Set<String> getWebSocketAllowedOrigins() {
+        return websocketAllowedOrigins;
     }
 
     boolean isTLSEnabled() {
@@ -322,8 +327,33 @@ public class RestServer extends QBeanSupport implements Runnable, XmlConfigurabl
         validateHeaders = cfg.getBoolean("validateHeaders", DEFAULT_CHUNKED_SUPPORTED);
         websocketPath = cfg.get("websocket-path", null);
         maxWebSocketFrameSize = cfg.getInt("maxWebSocketFrameSize", DEFAULT_MAX_WEBSOCKET_FRAME_SIZE);
+        websocketAllowedOrigins = parseWebSocketAllowedOrigins(cfg);
         pathLabel = QRestMetrics.parsePathLabel(cfg.get("metrics-path-label", "route"));
         metricsMaxRoutes = cfg.getInt("metrics-max-routes", 200);
+    }
+
+    private static Set<String> parseWebSocketAllowedOrigins(Configuration cfg) {
+        Set<String> origins = new LinkedHashSet<>();
+        addOrigins(origins, cfg.get("websocket-allowed-origins", null));
+        String[] repeated = cfg.getAll("websocket-allowed-origin");
+        if (repeated != null) {
+            for (String origin : repeated) {
+                addOrigins(origins, origin);
+            }
+        }
+        return Collections.unmodifiableSet(origins);
+    }
+
+    private static void addOrigins(Set<String> origins, String raw) {
+        if (raw == null) return;
+        for (String origin : raw.split(",")) {
+            String trimmed = origin.trim();
+            if (!trimmed.isEmpty()) {
+                String normalized = "*".equals(trimmed) ? trimmed :
+                  WebSocketUpgradeHandler.normalizeOrigin(trimmed);
+                origins.add(normalized != null ? normalized : trimmed);
+            }
+        }
     }
 
     @Override

--- a/modules/qrest/src/main/java/org/jpos/qrest/WebSocketUpgradeHandler.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/WebSocketUpgradeHandler.java
@@ -20,16 +20,24 @@ package org.jpos.qrest;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
 
 import java.util.HashMap;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -81,6 +89,15 @@ public class WebSocketUpgradeHandler extends ChannelInboundHandlerAdapter {
     }
 
     private void handleWebSocketUpgrade(ChannelHandlerContext ctx, FullHttpRequest request) {
+        if (!isAllowedOrigin(ctx, request)) {
+            server.getLog().warn("Rejected WebSocket cross-site Origin: " +
+                request.headers().get(HttpHeaderNames.ORIGIN) + " path=" + request.uri());
+            ctx.writeAndFlush(new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.FORBIDDEN
+            )).addListener(ChannelFutureListener.CLOSE);
+            return;
+        }
+
         String wsUrl = getWebSocketUrl(ctx, request);
 
         WebSocketServerHandshakerFactory wsFactory = new WebSocketServerHandshakerFactory(
@@ -137,6 +154,50 @@ public class WebSocketUpgradeHandler extends ChannelInboundHandlerAdapter {
         String scheme = ctx.pipeline().get("ssl") != null ? "wss" : "ws";
         String host = request.headers().get(HttpHeaderNames.HOST);
         return scheme + "://" + host + request.uri();
+    }
+
+    private boolean isAllowedOrigin(ChannelHandlerContext ctx, FullHttpRequest request) {
+        String origin = request.headers().get(HttpHeaderNames.ORIGIN);
+        if (origin == null || origin.isBlank()) return true;
+
+        Set<String> allowed = server.getWebSocketAllowedOrigins();
+        if (allowed.contains("*") || allowed.contains(origin)) return true;
+
+        String normalized = normalizeOrigin(origin);
+        return normalized != null &&
+            (allowed.contains(normalized) ||
+             isSameOrigin(ctx.pipeline().get("ssl") != null,
+                 request.headers().get(HttpHeaderNames.HOST), normalized));
+    }
+
+    static boolean isSameOrigin(boolean tls, String hostHeader, String origin) {
+        if (hostHeader == null || hostHeader.isBlank()) return false;
+        String expectedScheme = tls ? "https" : "http";
+        String expected = normalizeHostOrigin(expectedScheme, hostHeader);
+        return expected != null && expected.equals(normalizeOrigin(origin));
+    }
+
+    static String normalizeOrigin(String origin) {
+        try {
+            URI uri = new URI(origin);
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            if (scheme == null || host == null) return null;
+            scheme = scheme.toLowerCase(Locale.ROOT);
+            if (!scheme.equals("http") && !scheme.equals("https")) return null;
+            int port = uri.getPort() >= 0 ? uri.getPort() : defaultPort(scheme);
+            return scheme + "://" + host.toLowerCase(Locale.ROOT) + ":" + port;
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    private static String normalizeHostOrigin(String scheme, String hostHeader) {
+        return normalizeOrigin(scheme + "://" + hostHeader);
+    }
+
+    private static int defaultPort(String scheme) {
+        return "https".equals(scheme) ? 443 : 80;
     }
 
     /**

--- a/modules/qrest/src/test/java/org/jpos/qrest/WebSocketOriginCheckTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/WebSocketOriginCheckTest.java
@@ -1,0 +1,60 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.qrest;
+
+import org.jpos.core.SimpleConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WebSocketOriginCheckTest {
+    @Test
+    void acceptsSameHttpOrigin() {
+        assertTrue(WebSocketUpgradeHandler.isSameOrigin(
+            false, "example.test:8080", "http://example.test:8080"));
+    }
+
+    @Test
+    void acceptsDefaultPorts() {
+        assertTrue(WebSocketUpgradeHandler.isSameOrigin(
+            false, "example.test", "http://example.test"));
+        assertTrue(WebSocketUpgradeHandler.isSameOrigin(
+            true, "example.test", "https://example.test"));
+    }
+
+    @Test
+    void rejectsCrossSiteOrigin() {
+        assertFalse(WebSocketUpgradeHandler.isSameOrigin(
+            false, "example.test:8080", "http://evil.test:8080"));
+        assertFalse(WebSocketUpgradeHandler.isSameOrigin(
+            false, "example.test:8080", "https://example.test:8080"));
+    }
+
+    @Test
+    void normalizesConfiguredAllowedOrigins() throws Exception {
+        SimpleConfiguration cfg = new SimpleConfiguration();
+        cfg.put("websocket-allowed-origins", "https://admin.example.test, http://localhost:8080");
+
+        RestServer server = new RestServer();
+        server.setConfiguration(cfg);
+
+        assertTrue(server.getWebSocketAllowedOrigins().contains("https://admin.example.test:443"));
+        assertTrue(server.getWebSocketAllowedOrigins().contains("http://localhost:8080"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a qrest-level WebSocket Origin guard before the upgrade handshake
- allow browser WebSockets by default only for same-origin requests
- add `websocket-allowed-origin` / `websocket-allowed-origins` configuration for explicit external origins

Refs ar/mgl#164.

## Tests
- `./gradlew :modules:qrest:test --tests org.jpos.qrest.WebSocketOriginCheckTest --tests org.jpos.qrest.WebSocketPathPatternTest`