### PR TITLE
feat: add Duration transaction timeouts

### DIFF
--- a/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
+++ b/modules/dbsupport/src/main/java/org/jpos/ee/DB.java
@@ -51,6 +51,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -614,6 +615,31 @@ public class DB implements Closeable {
         return tx;
     }
 
+    /**
+     * Begins a transaction with the given timeout.
+     *
+     * <p>A zero duration preserves the session-defined default. Hibernate
+     * provides transaction timeouts with one-second accuracy, so positive
+     * durations with a fractional second are rounded up.</p>
+     *
+     * @param timeout transaction timeout
+     * @return newly created Transaction
+     * @throws IllegalArgumentException if the timeout is negative or too large
+     * @throws HibernateException if the transaction cannot be started
+     */
+    public synchronized Transaction beginTransaction(Duration timeout) throws HibernateException
+    {
+        if (timeout.isNegative())
+            throw new IllegalArgumentException("timeout must not be negative");
+        if (timeout.isZero())
+            return beginTransaction();
+
+        long seconds = timeout.toSeconds();
+        if (seconds > Integer.MAX_VALUE || (seconds == Integer.MAX_VALUE && timeout.getNano() > 0))
+            throw new IllegalArgumentException("timeout is too large");
+        return beginTransaction((int) seconds + (timeout.getNano() > 0 ? 1 : 0));
+    }
+
     public synchronized Log getLog()
     {
         if (log == null)
@@ -643,9 +669,26 @@ public class DB implements Closeable {
     }
 
     public static <T> T execWithTransaction(DBAction<T> action) throws Exception {
+        return execWithTransaction(action, Duration.ZERO);
+    }
+
+    /**
+     * Executes an action within a transaction using the given timeout.
+     *
+     * <p>A zero duration preserves the session-defined default. Hibernate
+     * provides transaction timeouts with one-second accuracy, so positive
+     * durations with a fractional second are rounded up.</p>
+     *
+     * @param action action to execute
+     * @param timeout transaction timeout
+     * @return the action result
+     * @param <T> action result type
+     * @throws Exception if the action or transaction fails
+     */
+    public static <T> T execWithTransaction(DBAction<T> action, Duration timeout) throws Exception {
         try (DB db = new DB()) {
             db.open();
-            db.beginTransaction();
+            db.beginTransaction(timeout);
             T obj = action.exec(db);
             db.commit();
             return obj;
@@ -653,9 +696,27 @@ public class DB implements Closeable {
     }
 
     public static <T> T execWithTransaction(String configModifier, DBAction<T> action) throws Exception {
+        return execWithTransaction(configModifier, action, Duration.ZERO);
+    }
+
+    /**
+     * Executes an action within a transaction using the given configuration and timeout.
+     *
+     * <p>A zero duration preserves the session-defined default. Hibernate
+     * provides transaction timeouts with one-second accuracy, so positive
+     * durations with a fractional second are rounded up.</p>
+     *
+     * @param configModifier configuration modifier
+     * @param action action to execute
+     * @param timeout transaction timeout
+     * @return the action result
+     * @param <T> action result type
+     * @throws Exception if the action or transaction fails
+     */
+    public static <T> T execWithTransaction(String configModifier, DBAction<T> action, Duration timeout) throws Exception {
         try (DB db = new DB(configModifier)) {
             db.open();
-            db.beginTransaction();
+            db.beginTransaction(timeout);
             T obj = action.exec(db);
             db.commit();
             return obj;

--- a/modules/dbsupport/src/test/java/org/jpos/ee/DBTest.java
+++ b/modules/dbsupport/src/test/java/org/jpos/ee/DBTest.java
@@ -26,6 +26,7 @@ import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Semaphore;
@@ -60,7 +61,7 @@ import java.util.concurrent.Semaphore;
  * </ul>
  * <p>
  * <h2>Transaction model in DB</h2>
- * {@code DB} has two {@code beginTransaction} overloads:
+ * {@code DB} has three {@code beginTransaction} overloads:
  * <dl>
  *   <dt>{@code beginTransaction()} (no-arg)</dt>
  *   <dd>Calls {@code session.beginTransaction()} — Hibernate creates and
@@ -74,6 +75,10 @@ import java.util.concurrent.Semaphore;
  *       {@code getTransaction()} returns the already-active transaction
  *       if one exists, so this overload can be called on a session that
  *       already has a transaction in progress.</dd>
+ *   <dt>{@code beginTransaction(Duration timeout)}</dt>
+ *   <dd>Uses the no-argument overload for {@code Duration.ZERO}; otherwise,
+ *       it rounds positive fractional seconds up before delegating to the
+ *       integer-seconds overload required by Hibernate.</dd>
  * </dl>
  * <p>
  * {@code commit()} and {@code rollback()} are guard methods:
@@ -359,6 +364,51 @@ class DBTest {
 
         verify(mockTx, never()).setTimeout(anyInt());
         verify(mockTx).begin();
+    }
+
+    @Test
+    void testBeginTransactionWithZeroDurationUsesSessionDefault() {
+        Session mockSession = mock(Session.class);
+        org.hibernate.Transaction mockTx = mock(org.hibernate.Transaction.class);
+        when(mockSession.beginTransaction()).thenReturn(mockTx);
+
+        DB db = new DB(mockSession);
+        db.beginTransaction(Duration.ZERO);
+
+        verify(mockSession).beginTransaction();
+        verify(mockSession, never()).getTransaction();
+    }
+
+    @Test
+    void testBeginTransactionWithDurationRoundsUpToSeconds() {
+        Session mockSession = mock(Session.class);
+        org.hibernate.Transaction mockTx = mock(org.hibernate.Transaction.class);
+        when(mockSession.getTransaction()).thenReturn(mockTx);
+
+        DB db = new DB(mockSession);
+        db.beginTransaction(Duration.ofMillis(1001));
+
+        verify(mockTx).setTimeout(2);
+        verify(mockTx).begin();
+    }
+
+    @Test
+    void testBeginTransactionWithNegativeDurationFails() {
+        Session mockSession = mock(Session.class);
+        DB db = new DB(mockSession);
+
+        assertThrows(IllegalArgumentException.class, () -> db.beginTransaction(Duration.ofSeconds(-1)));
+        verifyNoInteractions(mockSession);
+    }
+
+    @Test
+    void testBeginTransactionWithOversizedDurationFails() {
+        Session mockSession = mock(Session.class);
+        DB db = new DB(mockSession);
+
+        assertThrows(IllegalArgumentException.class,
+          () -> db.beginTransaction(Duration.ofSeconds((long) Integer.MAX_VALUE + 1)));
+        verifyNoInteractions(mockSession);
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add Duration overloads for DB transaction execution
- preserve the existing overloads by delegating with Duration.ZERO
- document Hibernate’s whole-second timeout accuracy and round positive fractional seconds up

## Verification

- ./gradlew :modules:dbsupport:test --no-daemon
- ./gradlew :modules:dbsupport:javadoc --no-daemon