### PR TITLE
qrest: inhibit transport context keys

### DIFF
--- a/modules/qrest-crud/src/main/java/org/jpos/qrest/ExtractJSONObject.java
+++ b/modules/qrest-crud/src/main/java/org/jpos/qrest/ExtractJSONObject.java
@@ -124,7 +124,7 @@ public class  ExtractJSONObject implements TransactionParticipant, Configurable 
                 ctx.put(RESPONSE, new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST));
                 return null;
             }
-            ctx.remove(JSON_REQUEST.name()); // unclutter context
+            ctx.remove(JSON_REQUEST); // unclutter context
         } catch (JsonProcessingException e) {
             ctx.log (e);
         }

--- a/modules/qrest-crud/src/main/java/org/jpos/qrest/crud/participant/CRUD.java
+++ b/modules/qrest-crud/src/main/java/org/jpos/qrest/crud/participant/CRUD.java
@@ -348,7 +348,7 @@ public abstract class CRUD<T, I, O> implements TransactionParticipant, Configura
     protected @Nullable T getAndValidateEntity(Context ctx) {
         T entity = null;
         try {
-            String jsonRequest = ctx.get(JSON_REQUEST.name());
+            String jsonRequest = ctx.get(JSON_REQUEST);
             entity = fromDTO(ctx, Converter.getMapper().readValue(jsonRequest, getManagedDTOInputClass()));
             if (!isValidId(entity, ctx)) {
                 ctx.put(TEMP_RESPONSE, new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST));
@@ -362,7 +362,7 @@ public abstract class CRUD<T, I, O> implements TransactionParticipant, Configura
                 ctx.put(TEMP_RESPONSE, new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST));
                 return null;
             }
-            ctx.remove(JSON_REQUEST.name()); // unclutter context
+            ctx.remove(JSON_REQUEST); // unclutter context
         } catch (QRestException e) {
             ctx.log(e.getMessage() + " (" + Caller.info(0) + ")");
             ctx.put(TEMP_RESPONSE, e.getResponse());

--- a/modules/qrest/src/main/java/org/jpos/qrest/Constants.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/Constants.java
@@ -18,7 +18,9 @@
 
 package org.jpos.qrest;
 
-public enum Constants {
+import org.jpos.util.Inhibit;
+
+public enum Constants implements Inhibit {
     SESSION,
     REQUEST,
     JSON_REQUEST,

--- a/modules/qrest/src/main/java/org/jpos/qrest/ExtractJSONRequest.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/ExtractJSONRequest.java
@@ -33,7 +33,7 @@ public class ExtractJSONRequest implements TransactionParticipant {
     public int prepare(long id, Serializable context) {
         Context ctx = (Context) context;
         FullHttpRequest request = ctx.get(REQUEST);
-        ctx.put (JSON_REQUEST.name(), request.content().toString(CharsetUtil.UTF_8));
+        ctx.put (JSON_REQUEST, request.content().toString(CharsetUtil.UTF_8));
         return PREPARED | READONLY | NO_JOIN;
     }
 }

--- a/modules/qrest/src/main/java/org/jpos/qrest/ValidateParams.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/ValidateParams.java
@@ -231,7 +231,7 @@ public class ValidateParams implements TransactionParticipant, XmlConfigurable {
     private boolean checkMandatoryJson (Context ctx) {
         boolean validParams = true;
         for (Map.Entry<String,JsonSchema> entry : mandatoryJson.entrySet()) {
-            String value = ctx.getString(entry.getKey());
+            String value = ctx.getString(contextKey(entry.getKey()));
             ProcessingReport report;
             if (value != null) {
                 try {
@@ -254,7 +254,7 @@ public class ValidateParams implements TransactionParticipant, XmlConfigurable {
     private boolean checkOptionalJson (Context ctx) {
         boolean validParams = true;
         for (Map.Entry<String,JsonSchema> entry : optionalJson.entrySet()) {
-            String value = ctx.getString(entry.getKey());
+            String value = ctx.getString(contextKey(entry.getKey()));
             ProcessingReport report;
             if (value != null) {
                 try {
@@ -272,5 +272,9 @@ public class ValidateParams implements TransactionParticipant, XmlConfigurable {
             }
         }
         return validParams;
+    }
+
+    private Object contextKey(String name) {
+        return Constants.JSON_REQUEST.name().equals(name) ? Constants.JSON_REQUEST : name;
     }
 }

--- a/modules/qrest/src/main/java/org/jpos/qrest/WsConstants.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/WsConstants.java
@@ -18,10 +18,12 @@
 
 package org.jpos.qrest;
 
+import org.jpos.util.Inhibit;
+
 /**
  * Constants for WebSocket-related context keys.
  */
-public enum WsConstants {
+public enum WsConstants implements Inhibit {
     /** The WebSocketSession handler for the connection */
     WS_SESSION,
     /** The WebSocket frame content (text or binary) */

--- a/modules/qrest/src/main/java/org/jpos/qrest/participant/DebugHttpContext.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/participant/DebugHttpContext.java
@@ -1,0 +1,133 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.qrest.participant;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponse;
+import org.jpos.core.Configurable;
+import org.jpos.core.Configuration;
+import org.jpos.core.ConfigurationException;
+import org.jpos.qrest.HttpParams;
+import org.jpos.qrest.Response;
+import org.jpos.transaction.Context;
+import org.jpos.transaction.TransactionParticipant;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.jpos.qrest.Constants.*;
+
+/**
+ * Logs a safe summary of the HTTP values inhibited from ordinary Context output.
+ *
+ * <p>The optional {@code headers} and {@code params} properties are comma or
+ * whitespace-separated allowlists. Sensitive names are always redacted and
+ * request and response bodies are never logged.</p>
+ */
+public class DebugHttpContext implements TransactionParticipant, Configurable {
+    private static final int MAX_VALUE_LENGTH = 256;
+    private static final HttpParams PARAM_MASKER = new HttpParams();
+    private Set<String> headers = Set.of();
+    private Set<String> params = Set.of();
+
+    @Override
+    public void setConfiguration(Configuration cfg) throws ConfigurationException {
+        headers = names(cfg.get("headers", ""));
+        params = names(cfg.get("params", ""));
+    }
+
+    @Override
+    public int prepare(long id, Serializable context) {
+        Context ctx = (Context) context;
+        logRequest(ctx);
+        logResponse(ctx);
+        return PREPARED | READONLY | NO_JOIN;
+    }
+
+    private void logRequest(Context ctx) {
+        FullHttpRequest request = ctx.get(REQUEST);
+        if (request == null)
+            return;
+        ctx.log(String.format("HTTP request method=%s path=%s bytes=%d",
+          request.method(), path(request.uri()), request.content().readableBytes()));
+        headers.forEach(name -> logHeader(ctx, request, name));
+        logParams(ctx, "query", ctx.get(QUERYPARAMS));
+        logParams(ctx, "path", ctx.get(PATHPARAMS));
+        logParams(ctx, "form", ctx.get(FORMPARAMS));
+    }
+
+    private void logHeader(Context ctx, FullHttpRequest request, String name) {
+        String value = request.headers().get(name);
+        if (value != null)
+            ctx.log("HTTP request header " + name + "=" + display(name, value));
+    }
+
+    private void logParams(Context ctx, String source, Object value) {
+        if (!(value instanceof Map<?, ?> values))
+            return;
+        for (String name : params) {
+            Object param = values.get(name);
+            if (param != null)
+                ctx.log("HTTP " + source + " param " + name + "=" + display(name, param));
+        }
+    }
+
+    private void logResponse(Context ctx) {
+        Object response = ctx.get(RESPONSE);
+        if (response instanceof FullHttpResponse full)
+            ctx.log(String.format("HTTP response status=%d bytes=%d",
+              full.status().code(), full.content().readableBytes()));
+        else if (response instanceof HttpResponse http)
+            ctx.log("HTTP response status=" + http.status().code());
+        else if (response instanceof Response rest)
+            ctx.log("HTTP response status=" + rest.status().code());
+    }
+
+    private String display(String name, Object value) {
+        return sensitive(name) ? HttpParams.MASK : limit(String.valueOf(value));
+    }
+
+    private boolean sensitive(String name) {
+        String normalized = name.toLowerCase(Locale.ROOT);
+        return PARAM_MASKER.isMasked(name) || normalized.contains("authorization") || normalized.contains("cookie")
+          || normalized.contains("password") || normalized.contains("token") || normalized.contains("secret")
+          || normalized.contains("pin") || normalized.contains("cvv") || normalized.contains("key");
+    }
+
+    private String path(String uri) {
+        int query = uri.indexOf('?');
+        return limit(query < 0 ? uri : uri.substring(0, query));
+    }
+
+    private String limit(String value) {
+        String sanitized = value.replace('\r', ' ').replace('\n', ' ');
+        return sanitized.length() <= MAX_VALUE_LENGTH ? sanitized : sanitized.substring(0, MAX_VALUE_LENGTH) + "...";
+    }
+
+    private Set<String> names(String values) {
+        return Arrays.stream(values.split("[,\\s]+"))
+          .filter(s -> !s.isBlank())
+          .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/modules/qrest/src/test/java/org/jpos/qrest/DebugHttpContextTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/DebugHttpContextTest.java
@@ -1,0 +1,110 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.qrest;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.CharsetUtil;
+import org.jdom2.Element;
+import org.jpos.core.SimpleConfiguration;
+import org.jpos.qrest.participant.DebugHttpContext;
+import org.jpos.transaction.Context;
+import org.jpos.transaction.TransactionConstants;
+import org.jpos.util.Inhibit;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DebugHttpContextTest {
+    @Test
+    void qrestKeysAreInhibited() {
+        assertInstanceOf(Inhibit.class, Constants.REQUEST);
+        assertInstanceOf(Inhibit.class, WsConstants.WS_FRAME);
+    }
+
+    @Test
+    void extractsJsonUnderTheInhibitedEnumKey() {
+        Context ctx = new Context();
+        ctx.put(Constants.REQUEST, new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/login",
+          Unpooled.copiedBuffer("{\"password\":\"secret\"}", CharsetUtil.UTF_8)));
+
+        assertEquals(TransactionConstants.PREPARED | TransactionConstants.READONLY | TransactionConstants.NO_JOIN,
+          new ExtractJSONRequest().prepare(1L, ctx));
+        assertEquals("{\"password\":\"secret\"}", ctx.get(Constants.JSON_REQUEST));
+        assertNull(ctx.get(Constants.JSON_REQUEST.name()));
+    }
+
+    @Test
+    void validatesJsonConfiguredByTheOriginalStringKey() throws Exception {
+        Element config = new Element("participant");
+        config.addContent(new Element("mandatory").addContent(new Element("param")
+          .setAttribute("name", "JSON_REQUEST")
+          .setAttribute("type", "json-schema")
+          .setText("{\"type\":\"object\"}")));
+        ValidateParams participant = new ValidateParams();
+        participant.setConfiguration(config);
+        Context ctx = new Context();
+        ctx.put(Constants.JSON_REQUEST, "{\"name\":\"alice\"}");
+
+        assertEquals(TransactionConstants.PREPARED | TransactionConstants.READONLY | TransactionConstants.NO_JOIN,
+          participant.prepare(1L, ctx));
+    }
+
+    @Test
+    void logsOnlyAllowlistedSafeHttpDetails() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("headers", "Authorization, X-Request-ID");
+        props.setProperty("params", "password, limit");
+        DebugHttpContext participant = new DebugHttpContext();
+        participant.setConfiguration(new SimpleConfiguration(props));
+
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+          "/login?token=query-token", Unpooled.copiedBuffer("body-secret", CharsetUtil.UTF_8));
+        request.headers().set(HttpHeaderNames.AUTHORIZATION, "Bearer header-token");
+        request.headers().set("X-Request-ID", "request-42");
+        Context ctx = new Context();
+        ctx.put(Constants.REQUEST, request);
+        ctx.put(Constants.QUERYPARAMS, Map.of("limit", List.of("10")));
+        ctx.put(Constants.FORMPARAMS, Map.of("password", List.of("form-secret")));
+        ctx.put(Constants.RESPONSE, new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CREATED));
+
+        participant.prepare(1L, ctx);
+
+        String log = ctx.getLogEvent().getPayLoad().toString();
+        assertTrue(log.contains("method=POST path=/login bytes=11"));
+        assertTrue(log.contains("X-Request-ID=request-42"));
+        assertTrue(log.contains("query param limit=[10]"));
+        assertTrue(log.contains("Authorization=***"));
+        assertTrue(log.contains("form param password=***"));
+        assertTrue(log.contains("status=201 bytes=0"));
+        assertFalse(log.contains("header-token"));
+        assertFalse(log.contains("query-token"));
+        assertFalse(log.contains("body-secret"));
+        assertFalse(log.contains("form-secret"));
+    }
+}


### PR DESCRIPTION
Hides qrest HTTP and WebSocket transport Context entries from automatic logging through jPOS `Inhibit` keys.

Adds `DebugHttpContext`, an opt-in, safe-by-default diagnostic participant. It logs request/response metadata plus explicitly allowlisted headers and parameters; sensitive names are always redacted and bodies are never emitted.

Also moves `JSON_REQUEST` to the enum key and preserves existing `ValidateParams` XML configuration using `name="JSON_REQUEST"`.

Tests:
- `./gradlew :modules:qrest:test :modules:qrest-crud:test`
- `./gradlew :modules:qrest:test --tests org.jpos.qrest.DebugHttpContextTest --rerun-tasks`