### PR TITLE
build: remove disabled modules project setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
     group = 'org.jpos.ee'
     version = binding.variables.get("PROJECT_VERSION") ?: "0.0.1"
     def isSnapshot = version.contains("SNAPSHOT")
-    if (name != 'bom') {
+    if (name != 'bom' && project.path != ':modules') {
         apply plugin: 'maven-publish'
         apply plugin: 'signing'
         apply plugin: 'project-report'
@@ -161,16 +161,6 @@ subprojects {
                 maxParallelForks = Runtime.runtime.availableProcessors()
             }
         }
-        task aggregatedJavadoc (type: Javadoc, description: "Aggregated Javadocs") {
-            source subprojects.collect {project ->
-                project.sourceSets.main.allJava
-            }
-            destinationDir = new File(buildDir, 'docs/javadoc')
-            classpath = files(subprojects.collect { project ->
-                project.sourceSets.main.compileClasspath
-            })
-            failOnError = false
-        }
         repositories {
             maven {
                 url = 'file:///opt/local/maven'
@@ -200,16 +190,9 @@ subprojects {
     }
 }
 
-// Configure IDEA to use Git
+// Configure IDEA
 idea {
     project {
-        ipr {
-            withXml { 
-                provider -> provider.node.component.find { 
-                    it.@name == 'VcsDirectoryMappings' 
-                }.mapping.@vcs = 'Git' 
-            }
-        }
         languageLevel = '25'
     }
 }

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -1,6 +1,4 @@
 // The :modules project is just a container and shouldn't be built or have any artifacts
 // published, so we're disabling all tasks for it, and also flagging it as not producing a jar
 
-project.tasks.forEach{it.enabled = false}
-jar.enabled = false
-
+project.tasks.configureEach { it.enabled = false }


### PR DESCRIPTION
Removes build configuration from the disabled :modules container project.

This eliminates Gradle 10 deprecations from inherited project-property lookup and legacy IDEA IPR configuration.

Verification: ./gradlew help --warning-mode all; ./gradlew test --warning-mode all