### PR TITLE
qrest: mask auth headers in logged requests

### DIFF
--- a/modules/qrest/src/main/java/org/jpos/qrest/LoggeableHttpRequest.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/LoggeableHttpRequest.java
@@ -1,0 +1,317 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.qrest;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.jpos.util.Loggeable;
+
+import java.io.PrintStream;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * {@link FullHttpRequest} wrapper whose log renderings mask credential headers.
+ *
+ * <p>Participants read the real request through the regular
+ * {@code FullHttpRequest} interface, but the {@link Loggeable} dump used by
+ * {@code Context}'s XML output and {@link #toString()} render method, URI and
+ * protocol plus headers with {@code Authorization}, {@code Proxy-Authorization},
+ * {@code Cookie} and {@code Set-Cookie} values masked. Credential schemes and
+ * dotted key ids stay visible ({@code ApiKey cpk_x.***}), cookie names stay
+ * visible with values masked, and sensitive query parameter values in the URI
+ * are masked following {@link HttpParams} rules.</p>
+ *
+ * <p>Masking is always on and cannot be disabled; callers may only extend the
+ * built-in header list (see {@code RestSession}'s {@code masked-headers}
+ * property). Reference counting is delegated to the wrapped request, and
+ * copies ({@link #copy()}, {@link #duplicate()}, {@link #replace(ByteBuf)})
+ * remain masked.</p>
+ *
+ * @since 3.0.2
+ */
+public class LoggeableHttpRequest implements FullHttpRequest, Loggeable {
+    private static final Set<String> MASKED_HEADERS = Set.of(
+      "authorization", "proxy-authorization", "cookie", "set-cookie"
+    );
+    private static final HttpParams QUERY_MASKER = new HttpParams();
+
+    private final FullHttpRequest delegate;
+    private final Set<String> extraMasked;
+
+    public LoggeableHttpRequest(FullHttpRequest delegate) {
+        this(delegate, Set.of());
+    }
+
+    /**
+     * @param delegate    the real request
+     * @param extraMasked additional header names to mask, on top of the
+     *                    built-in list; matched case-insensitively
+     */
+    public LoggeableHttpRequest(FullHttpRequest delegate, Collection<String> extraMasked) {
+        this.delegate = delegate;
+        this.extraMasked = extraMasked.stream()
+          .filter(s -> s != null && !s.isBlank())
+          .map(s -> s.toLowerCase(Locale.ROOT))
+          .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /**
+     * @param name header name
+     * @return true if this header's value is masked in log output
+     */
+    public boolean isMasked(String name) {
+        String lower = name.toLowerCase(Locale.ROOT);
+        return MASKED_HEADERS.contains(lower) || extraMasked.contains(lower);
+    }
+
+    @Override
+    public void dump(PrintStream p, String indent) {
+        String inner = indent + "  ";
+        p.println(indent + "<http-request>");
+        p.println(inner + method() + " " + maskedUri() + " " + protocolVersion().text());
+        for (Map.Entry<String,String> entry : headers())
+            p.println(inner + entry.getKey() + ": " + maskedHeaderValue(entry.getKey(), entry.getValue()));
+        p.println(indent + "</http-request>");
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder()
+          .append(method()).append(' ').append(maskedUri()).append(' ').append(protocolVersion().text())
+          .append(" {");
+        boolean first = true;
+        for (Map.Entry<String,String> entry : headers()) {
+            if (!first)
+                sb.append(", ");
+            sb.append(entry.getKey()).append(": ").append(maskedHeaderValue(entry.getKey(), entry.getValue()));
+            first = false;
+        }
+        return sb.append('}').toString();
+    }
+
+    private String maskedHeaderValue(String name, String value) {
+        String lower = name.toLowerCase(Locale.ROOT);
+        if (!isMasked(name))
+            return value;
+        if ("cookie".equals(lower))
+            return maskCookiePairs(value, Integer.MAX_VALUE);
+        if ("set-cookie".equals(lower))
+            return maskCookiePairs(value, 1);
+        return maskCredential(value);
+    }
+
+    // "ApiKey cpk_x.secret" -> "ApiKey cpk_x.***": keep the scheme and, for
+    // dotted credentials, the key-id segment needed to correlate log entries
+    private static String maskCredential(String value) {
+        String v = value.trim();
+        int sp = v.indexOf(' ');
+        return sp > 0
+          ? v.substring(0, sp) + ' ' + maskToken(v.substring(sp + 1).trim())
+          : maskToken(v);
+    }
+
+    private static String maskToken(String token) {
+        int dot = token.indexOf('.');
+        return dot > 0 ? token.substring(0, dot + 1) + HttpParams.MASK : HttpParams.MASK;
+    }
+
+    private static String maskCookiePairs(String value, int maskedPairs) {
+        StringBuilder sb = new StringBuilder();
+        String[] segments = value.split(";");
+        for (int i = 0; i < segments.length; i++) {
+            String segment = segments[i].trim();
+            if (i > 0)
+                sb.append("; ");
+            if (i < maskedPairs) {
+                int eq = segment.indexOf('=');
+                sb.append(eq > 0 ? segment.substring(0, eq + 1) + HttpParams.MASK : HttpParams.MASK);
+            } else
+                sb.append(segment);
+        }
+        return sb.toString();
+    }
+
+    private String maskedUri() {
+        String uri = uri();
+        int q = uri.indexOf('?');
+        if (q < 0)
+            return uri;
+        StringBuilder sb = new StringBuilder(uri.substring(0, q + 1));
+        String[] params = uri.substring(q + 1).split("&");
+        for (int i = 0; i < params.length; i++) {
+            if (i > 0)
+                sb.append('&');
+            int eq = params[i].indexOf('=');
+            if (eq > 0 && QUERY_MASKER.isMasked(params[i].substring(0, eq)))
+                sb.append(params[i], 0, eq + 1).append(HttpParams.MASK);
+            else
+                sb.append(params[i]);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public HttpMethod method() {
+        return delegate.method();
+    }
+
+    @Deprecated
+    @Override
+    public HttpMethod getMethod() {
+        return delegate.method();
+    }
+
+    @Override
+    public FullHttpRequest setMethod(HttpMethod method) {
+        delegate.setMethod(method);
+        return this;
+    }
+
+    @Override
+    public String uri() {
+        return delegate.uri();
+    }
+
+    @Deprecated
+    @Override
+    public String getUri() {
+        return delegate.uri();
+    }
+
+    @Override
+    public FullHttpRequest setUri(String uri) {
+        delegate.setUri(uri);
+        return this;
+    }
+
+    @Override
+    public HttpVersion protocolVersion() {
+        return delegate.protocolVersion();
+    }
+
+    @Deprecated
+    @Override
+    public HttpVersion getProtocolVersion() {
+        return delegate.protocolVersion();
+    }
+
+    @Override
+    public FullHttpRequest setProtocolVersion(HttpVersion version) {
+        delegate.setProtocolVersion(version);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return delegate.headers();
+    }
+
+    @Override
+    public HttpHeaders trailingHeaders() {
+        return delegate.trailingHeaders();
+    }
+
+    @Override
+    public DecoderResult decoderResult() {
+        return delegate.decoderResult();
+    }
+
+    @Deprecated
+    @Override
+    public DecoderResult getDecoderResult() {
+        return delegate.decoderResult();
+    }
+
+    @Override
+    public void setDecoderResult(DecoderResult result) {
+        delegate.setDecoderResult(result);
+    }
+
+    @Override
+    public ByteBuf content() {
+        return delegate.content();
+    }
+
+    @Override
+    public FullHttpRequest copy() {
+        return new LoggeableHttpRequest(delegate.copy(), extraMasked);
+    }
+
+    @Override
+    public FullHttpRequest duplicate() {
+        return new LoggeableHttpRequest(delegate.duplicate(), extraMasked);
+    }
+
+    @Override
+    public FullHttpRequest retainedDuplicate() {
+        return new LoggeableHttpRequest(delegate.retainedDuplicate(), extraMasked);
+    }
+
+    @Override
+    public FullHttpRequest replace(ByteBuf content) {
+        return new LoggeableHttpRequest(delegate.replace(content), extraMasked);
+    }
+
+    @Override
+    public FullHttpRequest retain() {
+        delegate.retain();
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest retain(int increment) {
+        delegate.retain(increment);
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest touch() {
+        delegate.touch();
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest touch(Object hint) {
+        delegate.touch(hint);
+        return this;
+    }
+
+    @Override
+    public int refCnt() {
+        return delegate.refCnt();
+    }
+
+    @Override
+    public boolean release() {
+        return delegate.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return delegate.release(decrement);
+    }
+}

--- a/modules/qrest/src/main/java/org/jpos/qrest/RestSession.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/RestSession.java
@@ -35,8 +35,11 @@ import org.jpos.util.Logger;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import static io.netty.buffer.Unpooled.copiedBuffer;
 
@@ -44,6 +47,7 @@ public class RestSession extends ChannelInboundHandlerAdapter {
     private RestServer server;
     private String contentKey;
     private TrustedProxies trustedProxies;
+    private Set<String> maskedHeaders;
     private AttributeKey<HttpVersion> httpVersion = AttributeKey.valueOf("httpVersion");
 
     static final AttributeKey<RestAccessState> ACCESS_STATE = AttributeKey.valueOf("qrestAccessState");
@@ -56,6 +60,9 @@ public class RestSession extends ChannelInboundHandlerAdapter {
         contentKey = server.getConfiguration().get("content", null);
         trustedProxies = TrustedProxies.parse(
           server.getConfiguration().get("trusted-proxy-cidrs", null));
+        maskedHeaders = Arrays.stream(server.getConfiguration().get("masked-headers", "").split("[,\\s]+"))
+          .filter(s -> !s.isBlank())
+          .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override
@@ -82,7 +89,7 @@ public class RestSession extends ChannelInboundHandlerAdapter {
             captureRequest(ch, request);
             Context ctx = new Context();
             ctx.put(Constants.SESSION, ch);
-            ctx.put(Constants.REQUEST, request);
+            ctx.put(Constants.REQUEST, new LoggeableHttpRequest(request, maskedHeaders));
             ch.channel().attr(httpVersion).set(request.protocolVersion());
 
             if (contentKey != null)

--- a/modules/qrest/src/test/java/org/jpos/qrest/LoggeableHttpRequestTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/LoggeableHttpRequestTest.java
@@ -1,0 +1,203 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.qrest;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoggeableHttpRequestTest {
+    private static final String API_KEY = "ApiKey cpk_HZFAsGc5.aScGZUit1yhMpZgy";
+
+    @Test
+    void headersRemainReadableThroughInterface() {
+        LoggeableHttpRequest request = request();
+        assertEquals(API_KEY, request.headers().get("Authorization"));
+        assertEquals("JSESSIONID=abc123; theme=dark", request.headers().get("Cookie"));
+        assertEquals("localhost", request.headers().get("Host"));
+    }
+
+    @Test
+    void dumpMasksAuthorizationKeepingSchemeAndKeyId() {
+        String out = dump(request());
+        assertFalse(out.contains("aScGZUit1yhMpZgy"), "dump leaked the api secret: " + out);
+        assertTrue(out.contains("ApiKey cpk_HZFAsGc5.***"), "scheme and key id should stay visible: " + out);
+    }
+
+    @Test
+    void dumpMasksUndottedCredentialEntirely() {
+        LoggeableHttpRequest request = request();
+        request.headers().set("Authorization", "Basic dXNlcjpwYXNz");
+        String out = dump(request);
+        assertFalse(out.contains("dXNlcjpwYXNz"), "dump leaked the basic credential: " + out);
+        assertTrue(out.contains("Basic ***"));
+    }
+
+    @Test
+    void dumpMasksProxyAuthorization() {
+        LoggeableHttpRequest request = request();
+        request.headers().set("Proxy-Authorization", "Bearer plainsecret");
+        String out = dump(request);
+        assertFalse(out.contains("plainsecret"), "dump leaked the proxy credential: " + out);
+        assertTrue(out.contains("Bearer ***"));
+    }
+
+    @Test
+    void dumpMasksCookieValuesButKeepsNames() {
+        String out = dump(request());
+        assertFalse(out.contains("abc123"), "dump leaked a cookie value: " + out);
+        assertFalse(out.contains("theme=dark"), "dump leaked a cookie value: " + out);
+        assertTrue(out.contains("JSESSIONID=***"));
+        assertTrue(out.contains("theme=***"));
+    }
+
+    @Test
+    void dumpMasksSetCookieValueButKeepsAttributes() {
+        LoggeableHttpRequest request = request();
+        request.headers().set("Set-Cookie", "sid=s3cret; Path=/; HttpOnly");
+        String out = dump(request);
+        assertFalse(out.contains("s3cret"), "dump leaked the cookie value: " + out);
+        assertTrue(out.contains("sid=***; Path=/; HttpOnly"));
+    }
+
+    @Test
+    void dumpShowsMethodUriProtocolAndRegularHeaders() {
+        String out = dump(request());
+        assertTrue(out.contains("GET"));
+        assertTrue(out.contains("/login?nick=admin"));
+        assertTrue(out.contains("HTTP/1.1"));
+        assertTrue(out.contains("localhost"), "non-sensitive headers should stay visible: " + out);
+    }
+
+    @Test
+    void dumpMasksSensitiveQueryParamValues() {
+        String out = dump(request());
+        assertFalse(out.contains("admin8583"), "dump leaked a query credential: " + out);
+        assertTrue(out.contains("nick=admin"));
+        assertTrue(out.contains("password=***"));
+    }
+
+    @Test
+    void toStringMasksLikeDump() {
+        String s = request().toString();
+        assertFalse(s.contains("aScGZUit1yhMpZgy"), "toString leaked the api secret: " + s);
+        assertFalse(s.contains("abc123"), "toString leaked a cookie value: " + s);
+        assertFalse(s.contains("admin8583"), "toString leaked a query credential: " + s);
+        assertTrue(s.contains("ApiKey cpk_HZFAsGc5.***"));
+    }
+
+    @Test
+    void isMaskedMatchesCaseInsensitively() {
+        LoggeableHttpRequest request = request();
+        assertTrue(request.isMasked("authorization"));
+        assertTrue(request.isMasked("AUTHORIZATION"));
+        assertTrue(request.isMasked("Set-Cookie"));
+        assertFalse(request.isMasked("Host"));
+    }
+
+    @Test
+    void extraMaskedHeadersExtendDefaults() {
+        FullHttpRequest raw = rawRequest();
+        raw.headers().set("X-Api-Key", "sup3rs3cret");
+        LoggeableHttpRequest request = new LoggeableHttpRequest(raw, Set.of("X-Api-Key"));
+        assertTrue(request.isMasked("x-api-key"));
+        assertTrue(request.isMasked("Authorization"), "defaults must survive extension");
+        String out = dump(request);
+        assertFalse(out.contains("sup3rs3cret"), "dump leaked the extra masked header: " + out);
+        request.release();
+    }
+
+    @Test
+    void refCountingDelegates() {
+        LoggeableHttpRequest request = request();
+        assertEquals(1, request.refCnt());
+        assertSame(request, request.retain());
+        assertEquals(2, request.refCnt());
+        assertSame(request, request.touch());
+        assertSame(request, request.touch("hint"));
+        assertFalse(request.release());
+        assertTrue(request.release());
+        assertEquals(0, request.refCnt());
+    }
+
+    @Test
+    void contentRemainsReadable() {
+        FullHttpRequest raw = new DefaultFullHttpRequest(
+          HttpVersion.HTTP_1_1, HttpMethod.POST, "/login",
+          Unpooled.copiedBuffer("nick=admin", CharsetUtil.UTF_8));
+        LoggeableHttpRequest request = new LoggeableHttpRequest(raw);
+        assertEquals("nick=admin", request.content().toString(CharsetUtil.UTF_8));
+        request.release();
+    }
+
+    @Test
+    void copiesStayMasked() {
+        LoggeableHttpRequest request = request();
+        FullHttpRequest copy = request.copy();
+        assertInstanceOf(LoggeableHttpRequest.class, copy);
+        assertFalse(copy.toString().contains("aScGZUit1yhMpZgy"), "copy leaked the api secret");
+        FullHttpRequest replaced = request.replace(Unpooled.copiedBuffer("x", CharsetUtil.UTF_8));
+        assertInstanceOf(LoggeableHttpRequest.class, replaced);
+        assertInstanceOf(LoggeableHttpRequest.class, request.duplicate());
+        copy.release();
+        replaced.release();
+        request.release();
+    }
+
+    @Test
+    void mutatorsWriteThroughAndReturnWrapper() {
+        LoggeableHttpRequest request = request();
+        assertSame(request, request.setUri("/other"));
+        assertSame(request, request.setMethod(HttpMethod.PUT));
+        assertSame(request, request.setProtocolVersion(HttpVersion.HTTP_1_0));
+        assertEquals("/other", request.uri());
+        assertEquals(HttpMethod.PUT, request.method());
+        assertEquals(HttpVersion.HTTP_1_0, request.protocolVersion());
+        request.release();
+    }
+
+    private static LoggeableHttpRequest request() {
+        return new LoggeableHttpRequest(rawRequest());
+    }
+
+    private static FullHttpRequest rawRequest() {
+        FullHttpRequest raw = new DefaultFullHttpRequest(
+          HttpVersion.HTTP_1_1, HttpMethod.GET, "/login?nick=admin&password=admin8583");
+        raw.headers().set("Host", "localhost");
+        raw.headers().set("Authorization", API_KEY);
+        raw.headers().set("Cookie", "JSESSIONID=abc123; theme=dark");
+        return raw;
+    }
+
+    private static String dump(LoggeableHttpRequest request) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        request.dump(new PrintStream(baos), "  ");
+        return baos.toString();
+    }
+}

--- a/modules/qrest/src/test/java/org/jpos/qrest/RestSessionTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/RestSessionTest.java
@@ -21,6 +21,7 @@ package org.jpos.qrest;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -39,9 +40,12 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -135,6 +139,55 @@ class RestSessionTest {
           "channelInactive must not double-count a request that SendResponse already emitted");
 
         assertNoLegacyAcceptOrCloseLogs();
+    }
+
+    @Test
+    void queuedRequestMasksAuthHeadersInLogOutputButKeepsThemReadable() {
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+          HttpVersion.HTTP_1_1, HttpMethod.GET, "/q2/version");
+        request.headers().set("Authorization", "ApiKey cpk_HZFAsGc5.aScGZUit1yhMpZgy");
+        request.headers().set("Cookie", "JSESSIONID=abc123");
+        channel.writeInbound(request);
+
+        Context ctx = server.lastQueuedContext;
+        assertNotNull(ctx, "RestSession.channelRead must have queued a transaction Context");
+        FullHttpRequest queued = ctx.get(Constants.REQUEST);
+        assertInstanceOf(LoggeableHttpRequest.class, queued);
+        assertEquals("ApiKey cpk_HZFAsGc5.aScGZUit1yhMpZgy", queued.headers().get("Authorization"),
+          "real header must stay readable through the interface");
+        String rendered = queued.toString();
+        assertFalse(rendered.contains("aScGZUit1yhMpZgy"), "log rendering leaked the api secret");
+        assertFalse(rendered.contains("abc123"), "log rendering leaked the cookie value");
+        assertTrue(rendered.contains("ApiKey cpk_HZFAsGc5.***"));
+
+        ctx.put(Constants.RESPONSE, new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+        new SendResponse().commit(1L, ctx);
+        drainOutbound();
+        assertEquals(0, queued.refCnt(), "SendResponse must release the wrapped request");
+    }
+
+    @Test
+    void maskedHeadersPropertyExtendsDefaults() throws Exception {
+        CapturingRestServer extServer = new CapturingRestServer();
+        extServer.setName("rest-test-masked-headers");
+        Properties props = new Properties();
+        props.setProperty("masked-headers", "X-Api-Key");
+        extServer.setConfiguration(new SimpleConfiguration(props));
+        EmbeddedChannel extChannel = new EmbeddedChannel(new CapturingRestSession(extServer));
+        try {
+            DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+              HttpVersion.HTTP_1_1, HttpMethod.GET, "/q2/version");
+            request.headers().set("X-Api-Key", "sup3rs3cret");
+            extChannel.writeInbound(request);
+
+            FullHttpRequest queued = extServer.lastQueuedContext.get(Constants.REQUEST);
+            assertEquals("sup3rs3cret", queued.headers().get("X-Api-Key"));
+            String rendered = queued.toString();
+            assertFalse(rendered.contains("sup3rs3cret"), "configured masked header leaked");
+            assertTrue(rendered.contains("X-Api-Key"), "masked header names should stay visible");
+        } finally {
+            extChannel.finishAndReleaseAll();
+        }
     }
 
     @Test


### PR DESCRIPTION
The raw `FullHttpRequest` stored under the `REQUEST` context key rendered `Authorization`, `Proxy-Authorization` and `Cookie` values verbatim in any log rendering, and any downstream copy under a non-inhibited key reprinted them in full `Context` dumps.

`RestSession` now stores a `LoggeableHttpRequest`: a delegating wrapper implementing `FullHttpRequest` + `Loggeable`. Participants keep reading the real request through the interface (reference counting delegated, so `SendResponse`'s release path is unchanged), while `dump()`/`toString()` render method/URI/protocol plus headers with credential values masked:

- `Authorization` / `Proxy-Authorization`: scheme and dotted key id kept for correlation — `ApiKey cpk_x.***`, `Basic ***`
- `Cookie`: names visible, values masked — `JSESSIONID=***`
- `Set-Cookie`: first pair masked, attributes kept — `sid=***; Path=/; HttpOnly`
- URI query values masked following the `HttpParams` rules, so the dump cannot reprint what `QUERYPARAMS` masking hides

Masking is always on and cannot be disabled; the new `masked-headers` RestServer property can only extend the built-in header list, mirroring `masked-params` (dd109951). Copies (`copy()`/`duplicate()`/`replace()`) stay wrapped and masked.

Covered by `LoggeableHttpRequestTest` plus context-level tests in `RestSessionTest` (wrapper reaches the Context, headers stay readable, release path verified, `masked-headers` extension).