### PR TITLE
Register jPOS-EE kinds through the Kind registry and align module tags

### DIFF
--- a/modules/aws-payment-cryptography/src/main/java/org/jpos/security/paymentcrypto/PaymentCryptographyAdapter.java
+++ b/modules/aws-payment-cryptography/src/main/java/org/jpos/security/paymentcrypto/PaymentCryptographyAdapter.java
@@ -312,7 +312,7 @@ public class PaymentCryptographyAdapter extends BaseSMAdapter<SecureKey> {
     protected SecureKey importKeyImpl(SecureKey kek, SecureKey key, SecureKeySpec keySpec, boolean checkParity)
       throws SMException {
 
-        LogEvent evt = new LogEvent(this, "apc-operation");
+        LogEvent evt = new LogEvent(this, PaymentCryptographyLogEventProvider.APC_OPERATION);
         List<Loggeable> params = new ArrayList<>();
 
         try {
@@ -432,7 +432,7 @@ public class PaymentCryptographyAdapter extends BaseSMAdapter<SecureKey> {
     protected EncryptedPIN translatePINImpl(EncryptedPIN pinUnderKd1, SecureKey kd1, SecureKey kd2,
                                             byte destinationPINBlockFormat) throws SMException {
 
-        LogEvent evt = new LogEvent(this, "apc-operation");
+        LogEvent evt = new LogEvent(this, PaymentCryptographyLogEventProvider.APC_OPERATION);
         List<Loggeable> params = new ArrayList<>();
 
         try {

--- a/modules/aws-payment-cryptography/src/main/java/org/jpos/security/paymentcrypto/PaymentCryptographyLogEventProvider.java
+++ b/modules/aws-payment-cryptography/src/main/java/org/jpos/security/paymentcrypto/PaymentCryptographyLogEventProvider.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.jpos.qrest.evt;
+package org.jpos.security.paymentcrypto;
 
 import org.jpos.log.AuditLogEventProvider;
 import org.jpos.log.AuditLogEventType;
@@ -26,22 +26,20 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Registers QRest's structured audit-log event types via {@link java.util.ServiceLoader}.
+ * Registers the log kinds emitted by the AWS Payment Cryptography adapter
+ * via {@link java.util.ServiceLoader}.
  */
-public class QRestAuditLogEventProvider implements AuditLogEventProvider {
-    /** Kind of a REST access-log event. */
-    public static final String QREST_ACCESS = "qrest-access";
+public class PaymentCryptographyLogEventProvider implements AuditLogEventProvider {
+    /** Kind of the adapter's AWS-specific operations (the generic ones use {@link Kind#S_M_OPERATION}). */
+    public static final String APC_OPERATION = "apc-operation";
 
     @Override
     public Collection<AuditLogEventType> types() {
-        return List.of(
-          new AuditLogEventType(QREST_ACCESS, QRestAccess.class, QREST_ACCESS),
-          new AuditLogEventType("http-params", HttpParamsEvt.class) // secondary payload, implies no kind
-        );
+        return List.of();
     }
 
     @Override
     public Collection<Kind.Def> kinds() {
-        return List.of(new Kind.Def(QREST_ACCESS, Kind.Family.TELEMETRY));
+        return List.of(new Kind.Def(APC_OPERATION, Kind.Family.SECURITY));
     }
 }

--- a/modules/aws-payment-cryptography/src/main/resources/META-INF/services/org.jpos.log.AuditLogEventProvider
+++ b/modules/aws-payment-cryptography/src/main/resources/META-INF/services/org.jpos.log.AuditLogEventProvider
@@ -1,0 +1,1 @@
+org.jpos.security.paymentcrypto.PaymentCryptographyLogEventProvider

--- a/modules/aws-payment-cryptography/src/test/java/org/jpos/security/paymentcrypto/PaymentCryptographyAdapterTest.java
+++ b/modules/aws-payment-cryptography/src/test/java/org/jpos/security/paymentcrypto/PaymentCryptographyAdapterTest.java
@@ -228,4 +228,9 @@ public class PaymentCryptographyAdapterTest {
 
         assertThat(ISOUtil.hexString(encPIN.getPINBlock()), is(translatedPin));
     }
+    @org.junit.jupiter.api.Test
+    void apcOperationKindIsRegistered() {
+        org.junit.jupiter.api.Assertions.assertTrue(org.jpos.util.Kind.isRegistered(PaymentCryptographyLogEventProvider.APC_OPERATION));
+        org.junit.jupiter.api.Assertions.assertEquals(org.jpos.util.Kind.Family.SECURITY, org.jpos.util.Kind.family(PaymentCryptographyLogEventProvider.APC_OPERATION));
+    }
 }

--- a/modules/client-simulator/src/main/java/org/jpos/simulator/ClientSimulatorLogEventProvider.java
+++ b/modules/client-simulator/src/main/java/org/jpos/simulator/ClientSimulatorLogEventProvider.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.jpos.qrest.evt;
+package org.jpos.simulator;
 
 import org.jpos.log.AuditLogEventProvider;
 import org.jpos.log.AuditLogEventType;
@@ -26,22 +26,20 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Registers QRest's structured audit-log event types via {@link java.util.ServiceLoader}.
+ * Registers the log kinds emitted by the client simulator
+ * via {@link java.util.ServiceLoader}.
  */
-public class QRestAuditLogEventProvider implements AuditLogEventProvider {
-    /** Kind of a REST access-log event. */
-    public static final String QREST_ACCESS = "qrest-access";
+public class ClientSimulatorLogEventProvider implements AuditLogEventProvider {
+    /** Kind of a test-suite results report. */
+    public static final String RESULTS = "clientsim-results";
 
     @Override
     public Collection<AuditLogEventType> types() {
-        return List.of(
-          new AuditLogEventType(QREST_ACCESS, QRestAccess.class, QREST_ACCESS),
-          new AuditLogEventType("http-params", HttpParamsEvt.class) // secondary payload, implies no kind
-        );
+        return List.of();
     }
 
     @Override
     public Collection<Kind.Def> kinds() {
-        return List.of(new Kind.Def(QREST_ACCESS, Kind.Family.TELEMETRY));
+        return List.of(new Kind.Def(RESULTS, Kind.Family.TELEMETRY));
     }
 }

--- a/modules/client-simulator/src/main/java/org/jpos/simulator/TestRunner.java
+++ b/modules/client-simulator/src/main/java/org/jpos/simulator/TestRunner.java
@@ -103,7 +103,7 @@ public class TestRunner
     private void runSuite (List suite, MUX mux, Interpreter bsh)
         throws ISOException, IOException, EvalError
     {
-        LogEvent evt = getLog().createLogEvent ("results");
+        LogEvent evt = getLog().createLogEvent (ClientSimulatorLogEventProvider.RESULTS);
         LogEvent evt_error = null;
         Iterator iter = suite.iterator();
         long start = System.currentTimeMillis();

--- a/modules/client-simulator/src/main/resources/META-INF/services/org.jpos.log.AuditLogEventProvider
+++ b/modules/client-simulator/src/main/resources/META-INF/services/org.jpos.log.AuditLogEventProvider
@@ -1,0 +1,1 @@
+org.jpos.simulator.ClientSimulatorLogEventProvider

--- a/modules/cryptoservice/src/main/java/org/jpos/crypto/CryptoService.java
+++ b/modules/cryptoservice/src/main/java/org/jpos/crypto/CryptoService.java
@@ -372,7 +372,7 @@ public final class CryptoService extends QBeanSupport implements Runnable, XmlCo
 
     private void registerKey(String k, String v, boolean override) throws Exception {
         ksProvider.put(k, v, override);
-        LogEvent evt = getLog().createLogEvent("security");
+        LogEvent evt = getLog().createLogEvent(Kind.SET_KEY);
         evt.addMessage("<id>" + k + "</id>");
         evt.addMessage(System.lineSeparator() + v);
         Logger.log(evt);

--- a/modules/groovy/src/main/java/org/jpos/transaction/participant/GroovyGroupSelector.java
+++ b/modules/groovy/src/main/java/org/jpos/transaction/participant/GroovyGroupSelector.java
@@ -24,6 +24,7 @@ import org.jdom2.Element;
 import org.jpos.core.ConfigurationException;
 import org.jpos.groovy.GroovySetup;
 import org.jpos.transaction.GroupSelector;
+import org.jpos.util.Kind;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
 
@@ -40,7 +41,7 @@ public class GroovyGroupSelector extends GroovyParticipant implements GroupSelec
 
     @Override
     public String select(long id, Serializable context) {
-        LogEvent ev = new LogEvent(this, "select");
+        LogEvent ev = new LogEvent(this, Kind.SELECT);
         String result = null;
         if (select == null)  {
             result =  defaultSelect(id, context); // nothing to do

--- a/modules/qrest/src/main/java/org/jpos/qrest/RestSession.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/RestSession.java
@@ -29,6 +29,7 @@ import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
 import org.jpos.qrest.evt.QRestAccess;
 import org.jpos.transaction.Context;
+import org.jpos.qrest.evt.QRestAuditLogEventProvider;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
 
@@ -187,7 +188,7 @@ public class RestSession extends ChannelInboundHandlerAdapter {
      * keep-alive session share it. Visible for testing.
      */
     protected void emitAccessLog(QRestAccess access, UUID traceId) {
-        LogEvent evt = new LogEvent(server.getLog(), "qrest-access");
+        LogEvent evt = new LogEvent(server.getLog(), QRestAuditLogEventProvider.QREST_ACCESS);
         if (traceId != null)
             evt.withTraceId(traceId);
         evt.addMessage(access);

--- a/modules/qrest/src/test/java/org/jpos/qrest/evt/QRestAccessTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/evt/QRestAccessTest.java
@@ -147,4 +147,11 @@ class QRestAccessTest {
 
         assertEquals("GET /health", evt.toString());
     }
+    @Test
+    void qrestAccessKindIsRegisteredAndImpliedByItsType() {
+        assertTrue(org.jpos.util.Kind.isRegistered(QRestAuditLogEventProvider.QREST_ACCESS), "kind registered");
+        assertEquals(org.jpos.util.Kind.Family.TELEMETRY, org.jpos.util.Kind.family(QRestAuditLogEventProvider.QREST_ACCESS));
+        assertEquals(QRestAuditLogEventProvider.QREST_ACCESS, org.jpos.util.Kind.kindOf("qrest-access"), "type implies the kind");
+        assertEquals(org.jpos.util.Kind.INFO, org.jpos.util.Kind.kindOf("http-params"), "secondary payload implies none");
+    }
 }

--- a/modules/saf/src/main/java/org/jpos/saf/SAF.java
+++ b/modules/saf/src/main/java/org/jpos/saf/SAF.java
@@ -231,7 +231,7 @@ public class SAF extends QBeanSupport implements Runnable, Loggeable {
                 metrics.sendExpired(mti, "max-retransmissions");
             if (isExpired(entry))
                 metrics.sendExpired(mti, "expired");
-            LogEvent evt = getLog().createLogEvent("saf-warning");
+            LogEvent evt = getLog().createWarn();
             if (isMaxRetransmission(entry))
                 evt.addMessage("max retransmission count (" + maxRetransmissions + ") has been reached.");
             if (isExpired(entry)) {


### PR DESCRIPTION
Implements #397. Requires jPOS 3.0.2-SNAPSHOT with jpos/jPOS#760 or later (published 2026-09-05).

## What

| Module | Change |
|---|---|
| qrest | `QRestAuditLogEventProvider` registers kind `qrest-access` (family `telemetry`) and declares it as the implied kind of the `qrest-access` type; `http-params` stays a secondary payload. `RestSession` uses the constant. |
| aws-payment-cryptography | New `PaymentCryptographyLogEventProvider` (plus `META-INF/services` entry) registers `apc-operation` (family `security`). Kept as its own kind: the generic SM operations already log as `s-m-operation` through `BaseSMAdapter`, and `apc-operation` marks the AWS-specific ones. |
| client-simulator | New `ClientSimulatorLogEventProvider` (plus services entry) registers `clientsim-results` (family `telemetry`). `TestRunner` uses the constant. |
| saf | `saf-warning` → `warn` (`createWarn()`) |
| cryptoservice | `security` → `Kind.SET_KEY`; `security` collided with a family name |
| groovy | `select` → `Kind.SELECT` |

## Tests

- `QRestAccessTest`: kind registered, family, type implies the kind, `http-params` implies none.
- `PaymentCryptographyAdapterTest`: `apc-operation` registered with family `security`.
- client-simulator has no test source set; verified by compilation.
- `:modules:qrest:test`, `:modules:aws-payment-cryptography:test`, and compile/javadoc of every touched module pass.

## Release note

Emitted tags change for three events: `saf-warning` → `warn`, cryptoservice key registration `security` → `set-key`, client-simulator `results` → `clientsim-results`. XML element names and JSONL `kind` values follow.
