### PR TITLE
fix(qrest): release pooled requests before asynchronous processing

### DIFF
--- a/doc/src/asciidoc/module_qrest.adoc
+++ b/doc/src/asciidoc/module_qrest.adoc
@@ -775,3 +775,38 @@ Connected (press CTRL+C to quit)
 < [/127.0.0.1:54321]: Hello everyone!
 ------------
 
+
+===== Request ownership and unanswered requests
+
+QRest detaches each aggregated HTTP request before placing it in the transaction
+Context: it copies the readable body into a Java byte array and copies the headers
+and trailers, then releases the original reference-counted Netty request in a
+`finally` block. The `REQUEST` value remains a masked `FullHttpRequest`, but its
+body is an unreleasable, unpooled heap view managed by GC with the Context. This
+costs one body copy (bounded by `maxContentLength`) and deliberately avoids
+keeping pooled/direct transport storage alive across a Space queue lease.
+`retain()` and `release()` on this snapshot do not govern its lifetime; ordinary
+`LoggeableHttpRequest` wrappers created by applications keep their delegate's
+reference-counting behavior. Copies created explicitly by participants still
+follow the Netty ownership rules of their backing buffers.
+
+Consequently, queue expiry, an omitted `SendResponse`, or a disconnect cannot leak
+the original pooled request, and closing a channel cannot free the body under a
+running participant. This does not cancel a queued or running transaction: its
+heap snapshot stays valid while application code retains it. The existing
+60-second Space lease remains a queue-residency limit, not a transaction deadline.
+
+The optional `request-timeout` property bounds the wait for a response, in seconds.
+It defaults to the existing `timeout` property (300 seconds by default); a value
+of zero disables this per-request deadline. Unlike the reader-idle timer, it is
+not extended by subsequent traffic on a keep-alive connection. On expiry QRest
+logs a response-timeout warning and closes the connection, completing outstanding
+access records without inventing an HTTP status. It does not send a synthetic
+response or cancel transaction processing. Configure it to accommodate legitimate
+long-running requests. Successful completion cancels the deadline.
+
+Access state is tracked per request and completed once on write completion,
+disconnect, handler removal, or response timeout. Failed writes are not recorded
+as successful responses. This fixes tracking of overlapping requests; it does
+not introduce HTTP pipelining response ordering. Applications should continue
+to avoid overlapping HTTP/1.1 requests on one connection.

--- a/doc/src/asciidoc/module_qrest.adoc
+++ b/doc/src/asciidoc/module_qrest.adoc
@@ -803,10 +803,19 @@ not extended by subsequent traffic on a keep-alive connection. On expiry QRest
 logs a response-timeout warning and closes the connection, completing outstanding
 access records without inventing an HTTP status. It does not send a synthetic
 response or cancel transaction processing. Configure it to accommodate legitimate
-long-running requests. Successful completion cancels the deadline.
+long-running requests. Successful completion cancels the deadline. With defaults,
+a request abandoned after its 60-second Space lease may wait until approximately
+300 seconds before the connection closes without a response; on an otherwise idle
+connection the reader-idle timer and response deadline fall due at roughly the
+same time. Neither mechanism detects lease expiry or synthesizes a 503.
 
 Access state is tracked per request and completed once on write completion,
 disconnect, handler removal, or response timeout. Failed writes are not recorded
 as successful responses. This fixes tracking of overlapping requests; it does
 not introduce HTTP pipelining response ordering. Applications should continue
 to avoid overlapping HTTP/1.1 requests on one connection.
+
+Client-visible compatibility note: QRest's exception handler now returns the fixed
+body `Internal Server Error` with HTTP 500 instead of exposing the exception's
+message. Exceptions with no message are handled the same way; their handling no
+longer fails while constructing the error response.

--- a/modules/qrest/src/main/java/org/jpos/qrest/Constants.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/Constants.java
@@ -23,6 +23,7 @@ import org.jpos.util.Inhibit;
 public enum Constants implements Inhibit {
     SESSION,
     REQUEST,
+    // Keep this an Inhibit key: a plain String key would expose access state in Context dumps.
     ACCESS_STATE,
     JSON_REQUEST,
     QUERYPARAMS,

--- a/modules/qrest/src/main/java/org/jpos/qrest/Constants.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/Constants.java
@@ -23,6 +23,7 @@ import org.jpos.util.Inhibit;
 public enum Constants implements Inhibit {
     SESSION,
     REQUEST,
+    ACCESS_STATE,
     JSON_REQUEST,
     QUERYPARAMS,
     PATHPARAMS,

--- a/modules/qrest/src/main/java/org/jpos/qrest/LoggeableHttpRequest.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/LoggeableHttpRequest.java
@@ -19,6 +19,8 @@
 package org.jpos.qrest;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -77,6 +79,32 @@ public class LoggeableHttpRequest implements FullHttpRequest, Loggeable {
           .filter(s -> s != null && !s.isBlank())
           .map(s -> s.toLowerCase(Locale.ROOT))
           .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /**
+     * Detach an aggregated request from Netty's reference-counted transport storage.
+     * The caller still owns, and must release, {@code request}.
+     *
+     * <p>The body is an independent Java byte array, not a pooled/direct buffer or
+     * a retained slice. Its unreleasable view deliberately follows the Context's
+     * GC lifetime: queue expiry, disconnects and missing response participants
+     * cannot leak a pooled buffer or invalidate a running participant's reads.
+     * Ordinary wrappers constructed with {@link #LoggeableHttpRequest(FullHttpRequest)}
+     * retain their original reference-counting semantics.</p>
+     *
+     * @param request source request
+     * @param extraMasked additional headers to mask
+     * @return independently owned, heap-backed request
+     */
+    static LoggeableHttpRequest snapshot(FullHttpRequest request, Collection<String> extraMasked) {
+        byte[] body = new byte[request.content().readableBytes()];
+        request.content().getBytes(request.content().readerIndex(), body);
+        FullHttpRequest copy = new DefaultFullHttpRequest(
+          request.protocolVersion(), request.method(), request.uri(),
+          Unpooled.unreleasableBuffer(Unpooled.wrappedBuffer(body)),
+          request.headers().copy(), request.trailingHeaders().copy());
+        copy.setDecoderResult(request.decoderResult());
+        return new LoggeableHttpRequest(copy, extraMasked);
     }
 
     /**

--- a/modules/qrest/src/main/java/org/jpos/qrest/QRestMetrics.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/QRestMetrics.java
@@ -163,19 +163,6 @@ final class QRestMetrics {
         }
     }
 
-    /**
-     * Records a failed request that never produced a normal response. Sets status to 500
-     * if missing and routes through {@link #requestCompleted(RestAccessState)} so the
-     * idempotency guarantee still holds.
-     */
-    void requestFailed(RestAccessState state, Throwable t) {
-        if (registry == null || state == null || state.recorded)
-            return;
-        if (state.status == null)
-            state.status = 500;
-        requestCompleted(state);
-    }
-
     private Tags tagsFor(RestAccessState state) {
         Tags tags = Tags.of(
           "http.request.method", normalizeMethod(state.method),

--- a/modules/qrest/src/main/java/org/jpos/qrest/RestAccessState.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/RestAccessState.java
@@ -23,13 +23,9 @@ import org.jpos.qrest.evt.QRestAccess;
 import java.time.Instant;
 
 /**
- * Per-channel mutable accumulator that gathers QRest request/response metadata
- * during a session and is converted to an immutable {@link QRestAccess} when
- * the session closes.
- *
- * <p>Held on the netty channel via {@link RestSession#ACCESS_STATE} so the
- * same instance is visible to {@link RestSession} (capture), {@link RestServer}
- * (queue selection), and {@link SendResponse} (response data).</p>
+ * Per-request access metadata, shared by the Context and the channel's pending
+ * set. Completion and deadline cancellation are serialized on this object.
+ * It deliberately holds no request body or Context reference.
  */
 final class RestAccessState {
     Instant ts;
@@ -45,6 +41,8 @@ final class RestAccessState {
     Long requestBytes;
     Long responseBytes;
     boolean recorded;
+    boolean completed;
+    java.util.concurrent.ScheduledFuture<?> deadline;
 
     QRestAccess toAccess() {
         Long elapsed = startNanos != null

--- a/modules/qrest/src/main/java/org/jpos/qrest/RestServer.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/RestServer.java
@@ -184,7 +184,7 @@ public class RestServer extends QBeanSupport implements Runnable, XmlConfigurabl
         RouteMatch match = resolveRoute(request);
         ChannelHandlerContext ch = ctx.get(Constants.SESSION);
         if (ch != null) {
-            RestAccessState state = ch.channel().attr(RestSession.ACCESS_STATE).get();
+            RestAccessState state = RestSession.accessState(ctx);
             if (state != null) {
                 state.queue = match.queue();
                 state.route = match.route();

--- a/modules/qrest/src/main/java/org/jpos/qrest/RestSession.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/RestSession.java
@@ -91,6 +91,8 @@ public class RestSession extends ChannelInboundHandlerAdapter {
             if (request.method().equals(HttpMethod.OPTIONS)) {
                 CorsConfig corsConfig = server.getCorsConfig(request);
                 if (corsConfig != null) {
+                    // CorsHandler releases consumed requests or transfers ownership downstream;
+                    // these requests must stay outside the snapshot/release finally below.
                     new CorsHandler(corsConfig).channelRead(ch, msg);
                     return;
                 }

--- a/modules/qrest/src/main/java/org/jpos/qrest/RestSession.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/RestSession.java
@@ -27,6 +27,7 @@ import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 import org.jpos.qrest.evt.QRestAccess;
 import org.jpos.transaction.Context;
 import org.jpos.qrest.evt.QRestAuditLogEventProvider;
@@ -39,6 +40,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -49,6 +52,8 @@ public class RestSession extends ChannelInboundHandlerAdapter {
     private String contentKey;
     private TrustedProxies trustedProxies;
     private Set<String> maskedHeaders;
+    private final int requestTimeout;
+    static final AttributeKey<Set<RestAccessState>> PENDING = AttributeKey.valueOf("qrestPendingAccess");
     private AttributeKey<HttpVersion> httpVersion = AttributeKey.valueOf("httpVersion");
 
     static final AttributeKey<RestAccessState> ACCESS_STATE = AttributeKey.valueOf("qrestAccessState");
@@ -58,6 +63,8 @@ public class RestSession extends ChannelInboundHandlerAdapter {
 
     RestSession(RestServer server) {
         this.server = server;
+        requestTimeout = server.getConfiguration().getInt("request-timeout",
+          server.getConfiguration().getInt("timeout", 300));
         contentKey = server.getConfiguration().get("content", null);
         trustedProxies = TrustedProxies.parse(
           server.getConfiguration().get("trusted-proxy-cidrs", null));
@@ -69,6 +76,7 @@ public class RestSession extends ChannelInboundHandlerAdapter {
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         super.handlerAdded(ctx);
+        ctx.channel().attr(PENDING).set(ConcurrentHashMap.newKeySet());
         ctx.channel().attr(ACCESS_EMITTER).set(this::emitAccessLog);
         ctx.channel().attr(TRACE_ID).set(UuidV7.randomUuidV7());
         QRestMetrics m = server.getMetrics();
@@ -87,15 +95,21 @@ public class RestSession extends ChannelInboundHandlerAdapter {
                     return;
                 }
             }
-            captureRequest(ch, request);
-            Context ctx = new Context();
-            ctx.put(Constants.SESSION, ch);
-            ctx.put(Constants.REQUEST, new LoggeableHttpRequest(request, maskedHeaders));
-            ch.channel().attr(httpVersion).set(request.protocolVersion());
-
-            if (contentKey != null)
-                ctx.put(contentKey, request.content().toString(CharsetUtil.UTF_8));
-            server.queue(request, ctx);
+            try {
+                // Never transfer pooled transport storage into a leased Space entry.
+                FullHttpRequest detached = LoggeableHttpRequest.snapshot(request, maskedHeaders);
+                RestAccessState state = captureRequest(ch, detached);
+                Context ctx = new Context();
+                ctx.put(Constants.SESSION, ch);
+                ctx.put(Constants.REQUEST, detached);
+                ctx.put(Constants.ACCESS_STATE, state);
+                ch.channel().attr(httpVersion).set(detached.protocolVersion());
+                if (contentKey != null)
+                    ctx.put(contentKey, detached.content().toString(CharsetUtil.UTF_8));
+                server.queue(detached, ctx);
+            } finally {
+                ReferenceCountUtil.release(request);
+            }
         } else {
             super.channelRead(ch, msg);
         }
@@ -120,19 +134,21 @@ public class RestSession extends ChannelInboundHandlerAdapter {
         Logger.log(evt);
 
         HttpVersion version = ctx.channel().attr(httpVersion).get();
+        if (version == null)
+            version = HttpVersion.HTTP_1_1;
 
         RestAccessState state = ctx.channel().attr(ACCESS_STATE).get();
-        if (state != null && state.status == null)
-            state.status = HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
-
-        QRestMetrics m = server.getMetrics();
-        if (m != null && state != null)
-            m.requestFailed(state, cause);
+        if (state != null) {
+            synchronized (state) {
+                if (!state.completed && state.status == null)
+                    state.status = HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
+            }
+        }
 
         ctx.writeAndFlush(new DefaultFullHttpResponse(
           version,
           HttpResponseStatus.INTERNAL_SERVER_ERROR,
-          copiedBuffer(cause.getMessage().getBytes())
+          copiedBuffer("Internal Server Error", CharsetUtil.UTF_8)
         ));
         ctx.close();
     }
@@ -145,13 +161,59 @@ public class RestSession extends ChannelInboundHandlerAdapter {
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         super.channelInactive(ctx);
-        RestAccessState state = ctx.channel().attr(ACCESS_STATE).getAndSet(null);
-        if (state != null) {
-            QRestMetrics m = server.getMetrics();
-            if (m != null)
-                m.requestCompleted(state);
-            emitAccessLog(state.toAccess(), ctx.channel().attr(TRACE_ID).get());
+        completePending(ctx);
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        try {
+            completePending(ctx);
+        } finally {
+            super.handlerRemoved(ctx);
         }
+    }
+
+    private static void completePending(ChannelHandlerContext ch) {
+        Set<RestAccessState> pending = ch.channel().attr(PENDING).get();
+        if (pending != null)
+            for (RestAccessState state : pending.toArray(RestAccessState[]::new))
+                completeAccess(ch, state, null, null);
+        // Compatibility for callers which install access state directly.
+        completeAccess(ch, ch.channel().attr(ACCESS_STATE).get(), null, null);
+    }
+
+    static RestAccessState accessState(Context ctx) {
+        RestAccessState state = ctx.get(Constants.ACCESS_STATE);
+        ChannelHandlerContext ch = ctx.get(Constants.SESSION);
+        return state != null || ch == null ? state : ch.channel().attr(ACCESS_STATE).get();
+    }
+
+    /** Complete each request once, even when write completion races channel closure. */
+    static boolean completeAccess(ChannelHandlerContext ch, RestAccessState state, Integer status, Long bytes) {
+        if (ch == null || state == null)
+            return false;
+        synchronized (state) {
+            if (state.completed)
+                return false;
+            state.completed = true;
+            if (state.deadline != null)
+                state.deadline.cancel(false);
+            if (status != null)
+                state.status = status;
+            if (bytes != null)
+                state.responseBytes = bytes;
+            ch.channel().attr(ACCESS_STATE).compareAndSet(state, null);
+            Set<RestAccessState> pending = ch.channel().attr(PENDING).get();
+            if (pending != null)
+                pending.remove(state);
+            QRestMetrics metrics = ch.channel().attr(METRICS).get();
+            if (metrics != null)
+                metrics.requestCompleted(state);
+            BiConsumer<QRestAccess, UUID> emitter = ch.channel().attr(ACCESS_EMITTER).get();
+            if (emitter != null)
+                emitter.accept(state.toAccess(), ch.channel().attr(TRACE_ID).get());
+        }
+        return true;
     }
 
     @Override
@@ -159,7 +221,6 @@ public class RestSession extends ChannelInboundHandlerAdapter {
         if (evt instanceof IdleStateEvent) {
             IdleState e = ((IdleStateEvent) evt).state();
             if (e == IdleState.READER_IDLE) {
-                ctx.fireChannelInactive();
                 ctx.close();
             }
         }
@@ -182,6 +243,16 @@ public class RestSession extends ChannelInboundHandlerAdapter {
             state.route = route;
     }
 
+    /** Set the route on this request, independent of other requests on the connection.
+     * @param ctx transaction context
+     * @param route matched route template
+     */
+    public static void setMatchedRouteForContext(Context ctx, String route) {
+        RestAccessState state = accessState(ctx);
+        if (state != null && route != null && !route.isEmpty())
+            state.route = route;
+    }
+
     /**
      * Emits one structured QRest audit-log event. The trace-id (a session-scoped
      * UUIDv7) is attached to the {@link LogEvent} so all events from the same
@@ -195,7 +266,7 @@ public class RestSession extends ChannelInboundHandlerAdapter {
         Logger.log(evt);
     }
 
-    private void captureRequest(ChannelHandlerContext ch, FullHttpRequest request) {
+    private RestAccessState captureRequest(ChannelHandlerContext ch, FullHttpRequest request) {
         RestAccessState state = new RestAccessState();
         state.ts = Instant.now();
         state.startNanos = System.nanoTime();
@@ -214,9 +285,21 @@ public class RestSession extends ChannelInboundHandlerAdapter {
         state.scheme = server.isTLSEnabled() ? "https" : "http";
         state.protocolVersion = stripProtocol(request.protocolVersion().text());
         ch.channel().attr(ACCESS_STATE).set(state);
+        ch.channel().attr(PENDING).get().add(state);
         QRestMetrics m = server.getMetrics();
         if (m != null)
             m.requestStarted(state);
+        if (requestTimeout > 0) {
+            state.deadline = ch.executor().schedule(() -> {
+                // This bounds response waiting, not transaction execution.
+                // A participant may still safely use its heap snapshot.
+                if (completeAccess(ch, state, null, null)) {
+                    server.getLog().warn("HTTP response timeout");
+                    ch.close();
+                }
+            }, requestTimeout, TimeUnit.SECONDS);
+        }
+        return state;
     }
 
     private static String stripProtocol(String text) {

--- a/modules/qrest/src/main/java/org/jpos/qrest/SendResponse.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/SendResponse.java
@@ -63,49 +63,47 @@ public class SendResponse implements AbortParticipant, Configurable {
     }
 
     private void respond(Context ctx) {
-        synchronized (ctx) {
-            ChannelHandlerContext ch = ctx.get(SESSION);
-            FullHttpRequest request = ctx.get(REQUEST);
-            FullHttpResponse response = null;
-            boolean handedOff = false;
-            RestAccessState state = RestSession.accessState(ctx);
-            try {
-                response = getResponse(ctx, protocolVersion(request));
-                if (ch == null || !ch.channel().isActive()) {
-                    RestSession.completeAccess(ch, state, null, null);
-                    return;
-                }
-                boolean keepAlive = request != null && HttpUtil.isKeepAlive(request);
-                HttpHeaders headers = response.headers();
-                if (keepAlive)
-                    headers.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
-                if (contentType != null)
-                    headers.set(HttpHeaderNames.CONTENT_TYPE, contentType);
-                long responseBytes = response.content().readableBytes();
-                int status = response.status().code();
-                headers.set(HttpHeaderNames.CONTENT_LENGTH, responseBytes);
-                ChannelFuture cf = ch.writeAndFlush(response);
-                handedOff = true;
-                cf.addListener(future -> {
-                    RestSession.completeAccess(ch, state,
-                      future.isSuccess() ? status : null, future.isSuccess() ? responseBytes : null);
-                    if (!future.isSuccess())
-                        ch.close();
-                });
-                if (!keepAlive)
-                    cf.addListener(ChannelFutureListener.CLOSE);
-            } catch (RuntimeException | Error e) {
+        ChannelHandlerContext ch = ctx.get(SESSION);
+        FullHttpRequest request = ctx.get(REQUEST);
+        FullHttpResponse response = null;
+        boolean handedOff = false;
+        RestAccessState state = RestSession.accessState(ctx);
+        try {
+            response = getResponse(ctx, protocolVersion(request));
+            if (ch == null || !ch.channel().isActive()) {
                 RestSession.completeAccess(ch, state, null, null);
-                if (ch != null)
+                return;
+            }
+            boolean keepAlive = request != null && HttpUtil.isKeepAlive(request);
+            HttpHeaders headers = response.headers();
+            if (keepAlive)
+                headers.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+            if (contentType != null)
+                headers.set(HttpHeaderNames.CONTENT_TYPE, contentType);
+            long responseBytes = response.content().readableBytes();
+            int status = response.status().code();
+            headers.set(HttpHeaderNames.CONTENT_LENGTH, responseBytes);
+            ChannelFuture cf = ch.writeAndFlush(response);
+            handedOff = true;
+            cf.addListener(future -> {
+                RestSession.completeAccess(ch, state,
+                  future.isSuccess() ? status : null, future.isSuccess() ? responseBytes : null);
+                if (!future.isSuccess())
                     ch.close();
-                throw e;
+            });
+            if (!keepAlive)
+                cf.addListener(ChannelFutureListener.CLOSE);
+        } catch (RuntimeException | Error e) {
+            RestSession.completeAccess(ch, state, null, null);
+            if (ch != null)
+                ch.close();
+            throw e;
+        } finally {
+            try {
+                if (!handedOff && response != null)
+                    ReferenceCountUtil.release(response);
             } finally {
-                try {
-                    if (!handedOff && response != null)
-                        ReferenceCountUtil.release(response);
-                } finally {
-                    releaseRequest(ctx, request);
-                }
+                releaseRequest(ctx, request);
             }
         }
     }

--- a/modules/qrest/src/main/java/org/jpos/qrest/SendResponse.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/SendResponse.java
@@ -20,6 +20,7 @@ package org.jpos.qrest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -27,15 +28,12 @@ import io.netty.handler.codec.http.*;
 import io.netty.util.ReferenceCountUtil;
 import org.jpos.core.Configurable;
 import org.jpos.core.Configuration;
-import org.jpos.qrest.evt.QRestAccess;
 import org.jpos.rc.Result;
 import org.jpos.transaction.AbortParticipant;
 import org.jpos.transaction.Context;
 
 import java.io.Serializable;
 import java.util.Map;
-import java.util.UUID;
-import java.util.function.BiConsumer;
 
 import static io.netty.buffer.Unpooled.copiedBuffer;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
@@ -56,58 +54,60 @@ public class SendResponse implements AbortParticipant, Configurable {
 
     @Override
     public void commit (long id, Serializable context) {
-        Context ctx = (Context) context;
-        ChannelHandlerContext ch = ctx.get(SESSION);
-        FullHttpRequest request = ctx.get(REQUEST);
-        FullHttpResponse response = getResponse(ctx, protocolVersion(request));
-        sendResponse(ctx, ch, request, response);
+        respond((Context) context);
     }
 
     @Override
     public void abort (long id, Serializable context) {
-        Context ctx = (Context) context;
-        ChannelHandlerContext ch = ctx.get(SESSION);
-        FullHttpRequest request = ctx.get(REQUEST);
-        FullHttpResponse response = getResponse(ctx, protocolVersion(request));
-        sendResponse(ctx, ch, request, response);
+        respond((Context) context);
     }
 
-    private void sendResponse (Context ctx, ChannelHandlerContext ch, FullHttpRequest request, FullHttpResponse response) {
-        boolean keepAlive = request != null && HttpUtil.isKeepAlive(request);
-        HttpHeaders headers = response.headers();
-        try {
-            if (keepAlive)
-                headers.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
-
-            if (contentType != null)
-                headers.set(HttpHeaderNames.CONTENT_TYPE, contentType);
-            long responseBytes = response.content().readableBytes();
-            headers.set(HttpHeaderNames.CONTENT_LENGTH, responseBytes);
-            captureResponse(ch, response, responseBytes);
-            ChannelFuture cf = ch.writeAndFlush(response);
-
-            if (!keepAlive)
-                cf.addListener(ChannelFutureListener.CLOSE);
-        } finally {
-            releaseRequest(ctx, request);
+    private void respond(Context ctx) {
+        synchronized (ctx) {
+            ChannelHandlerContext ch = ctx.get(SESSION);
+            FullHttpRequest request = ctx.get(REQUEST);
+            FullHttpResponse response = null;
+            boolean handedOff = false;
+            RestAccessState state = RestSession.accessState(ctx);
+            try {
+                response = getResponse(ctx, protocolVersion(request));
+                if (ch == null || !ch.channel().isActive()) {
+                    RestSession.completeAccess(ch, state, null, null);
+                    return;
+                }
+                boolean keepAlive = request != null && HttpUtil.isKeepAlive(request);
+                HttpHeaders headers = response.headers();
+                if (keepAlive)
+                    headers.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+                if (contentType != null)
+                    headers.set(HttpHeaderNames.CONTENT_TYPE, contentType);
+                long responseBytes = response.content().readableBytes();
+                int status = response.status().code();
+                headers.set(HttpHeaderNames.CONTENT_LENGTH, responseBytes);
+                ChannelFuture cf = ch.writeAndFlush(response);
+                handedOff = true;
+                cf.addListener(future -> {
+                    RestSession.completeAccess(ch, state,
+                      future.isSuccess() ? status : null, future.isSuccess() ? responseBytes : null);
+                    if (!future.isSuccess())
+                        ch.close();
+                });
+                if (!keepAlive)
+                    cf.addListener(ChannelFutureListener.CLOSE);
+            } catch (RuntimeException | Error e) {
+                RestSession.completeAccess(ch, state, null, null);
+                if (ch != null)
+                    ch.close();
+                throw e;
+            } finally {
+                try {
+                    if (!handedOff && response != null)
+                        ReferenceCountUtil.release(response);
+                } finally {
+                    releaseRequest(ctx, request);
+                }
+            }
         }
-    }
-
-    private void captureResponse(ChannelHandlerContext ch, FullHttpResponse response, long responseBytes) {
-        if (ch == null)
-            return;
-        RestAccessState state = ch.channel().attr(RestSession.ACCESS_STATE).getAndSet(null);
-        if (state == null)
-            return;
-        if (response != null)
-            state.status = response.status().code();
-        state.responseBytes = responseBytes;
-        QRestMetrics metrics = ch.channel().attr(RestSession.METRICS).get();
-        if (metrics != null)
-            metrics.requestCompleted(state);
-        BiConsumer<QRestAccess, UUID> emitter = ch.channel().attr(RestSession.ACCESS_EMITTER).get();
-        if (emitter != null)
-            emitter.accept(state.toAccess(), ch.channel().attr(RestSession.TRACE_ID).get());
     }
 
     private void releaseRequest (Context ctx, FullHttpRequest request) {
@@ -151,24 +151,22 @@ public class SendResponse implements AbortParticipant, Configurable {
                     isJson = true;
                 }
 
-                httpResponse = new DefaultFullHttpResponse(
-                  version,
-                  response.status(),
-                  copiedBuffer(responseBody));
-
-                HttpHeaders httpHeaders = httpResponse.headers();
-
-                for (Map.Entry<String, String> header : response.getHeaders().entrySet()) {
-                    httpHeaders.add(header.getKey(), header.getValue());
+                ByteBuf content = copiedBuffer(responseBody);
+                try {
+                    httpResponse = new DefaultFullHttpResponse(version, response.status(), content);
+                    HttpHeaders httpHeaders = httpResponse.headers();
+                    for (Map.Entry<String, String> header : response.getHeaders().entrySet())
+                        httpHeaders.add(header.getKey(), header.getValue());
+                    if (response.contentType() != null)
+                        httpHeaders.set(CONTENT_TYPE, response.contentType());
+                    else if (isJson)
+                        httpHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
+                    if (corsHeader != null)
+                        httpHeaders.add("Access-Control-Allow-Origin", corsHeader);
+                } catch (RuntimeException | Error e) {
+                    content.release();
+                    throw e;
                 }
-
-                if (response.contentType() != null)
-                    httpResponse.headers().set(CONTENT_TYPE, response.contentType());
-                else if (isJson)
-                    httpResponse.headers().set(CONTENT_TYPE, APPLICATION_JSON);
-
-                if (corsHeader != null)
-                    httpHeaders.add("Access-Control-Allow-Origin", corsHeader);
             } catch (JsonProcessingException e) {
                 ctx.log(e);
                 httpResponse = error(HttpResponseStatus.INTERNAL_SERVER_ERROR, version);

--- a/modules/qrest/src/main/java/org/jpos/qrest/participant/Q2Info.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/participant/Q2Info.java
@@ -62,7 +62,7 @@ public class Q2Info implements TransactionParticipant, Configurable {
 
         HttpResponseStatus status = HttpResponseStatus.NOT_FOUND;
         if (route.isPresent()) {
-            RestSession.setMatchedRoute(ctx.get(SESSION), route.get().path());
+            RestSession.setMatchedRouteForContext(ctx, route.get().path());
             if (route.get().isValid(path)) {
                 response = new LinkedHashMap<>();
                 response.putAll(route.get().apply(route.get(), path));

--- a/modules/qrest/src/main/java/org/jpos/qrest/participant/Router.java
+++ b/modules/qrest/src/main/java/org/jpos/qrest/participant/Router.java
@@ -65,7 +65,7 @@ public class Router implements GroupSelector, XmlConfigurable {
                 if (m != null)
                     ctx.put(PATHPARAMS, m);
 
-                RestSession.setMatchedRoute(ctx.get(SESSION), r.path());
+                RestSession.setMatchedRouteForContext(ctx, r.path());
 
                 ctx.log("Matched Route: "+r);
                 return r.apply(r, path);

--- a/modules/qrest/src/test/java/org/jpos/qrest/QRestMetricsTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/QRestMetricsTest.java
@@ -61,7 +61,6 @@ class QRestMetricsTest {
         RestAccessState s = state("GET", "/users/{id}", 200);
         m.requestStarted(s);
         m.requestCompleted(s);
-        m.requestFailed(s, new RuntimeException("x"));
         assertEquals(0L, m.activeRequests());
     }
 
@@ -138,29 +137,11 @@ class QRestMetricsTest {
         m.requestStarted(s);
         m.requestCompleted(s);
         m.requestCompleted(s);
-        m.requestFailed(s, new RuntimeException("late"));
 
         Timer t = reg.find(QRestMetrics.REQUEST_DURATION).timer();
         assertNotNull(t);
         assertEquals(1L, t.count(), "second completion call must be a no-op");
         assertEquals(0L, m.activeRequests(), "active gauge must not be decremented twice");
-    }
-
-    @Test
-    void requestFailedAssignsServerErrorStatusWhenMissing() {
-        SimpleMeterRegistry reg = new SimpleMeterRegistry();
-        QRestMetrics m = new QRestMetrics(reg, "rest", QRestMetrics.PathLabel.ROUTE, 100);
-        RestAccessState s = state("GET", "/boom", null);
-        s.status = null;
-
-        m.requestStarted(s);
-        m.requestFailed(s, new RuntimeException("boom"));
-
-        Timer t = reg.find(QRestMetrics.REQUEST_DURATION).timer();
-        assertNotNull(t);
-        assertEquals(1L, t.count());
-        assertEquals("500", tagMap(t).get("http.response.status_code"));
-        assertEquals("SERVER_ERROR", tagMap(t).get("outcome"));
     }
 
     @Test

--- a/modules/qrest/src/test/java/org/jpos/qrest/RequestOwnershipTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/RequestOwnershipTest.java
@@ -23,9 +23,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.cors.CorsConfig;
+import io.netty.handler.codec.http.cors.CorsConfigBuilder;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.jpos.core.SimpleConfiguration;
@@ -237,6 +240,84 @@ class RequestOwnershipTest {
         assertEquals(0, server.metrics.activeRequests());
     }
 
+    @Test
+    void corsPreflightReleasesPooledRequestWithoutQueueing() {
+        assertCorsOwnership(true, "https://allowed.test", HttpResponseStatus.OK);
+    }
+
+    @Test
+    void corsForbiddenRequestIsReleasedWithoutQueueing() {
+        assertCorsOwnership(false, "https://denied.test", HttpResponseStatus.FORBIDDEN);
+    }
+
+    @Test
+    void corsPassThroughTransfersOwnershipDownstream() {
+        // EmbeddedChannel captures unhandled inbound messages instead of releasing
+        // them like a normal pipeline tail. Install an explicit consuming handler.
+        java.util.concurrent.atomic.AtomicBoolean consumed = new java.util.concurrent.atomic.AtomicBoolean();
+        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                consumed.set(true);
+                ReferenceCountUtil.release(msg);
+            }
+        });
+        assertCorsOwnership(false, "https://allowed.test", null);
+        assertTrue(consumed.get());
+    }
+
+    private void assertCorsOwnership(boolean preflight, String origin, HttpResponseStatus expected) {
+        server.cors = CorsConfigBuilder.forOrigin("https://allowed.test")
+          .allowedRequestMethods(HttpMethod.POST).shortCircuit().build();
+        FullHttpRequest source = request("/cors", "body");
+        source.setMethod(HttpMethod.OPTIONS);
+        source.headers().set(HttpHeaderNames.ORIGIN, origin);
+        if (preflight)
+            source.headers().set(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "POST");
+        channel.writeInbound(source);
+        assertEquals(0, source.refCnt());
+        assertNull(server.last, "CORS-handled OPTIONS must not reach the TM queue");
+        assertEquals(0, server.metrics.activeRequests());
+        FullHttpResponse response = channel.readOutbound();
+        if (expected == null) {
+            assertNull(response);
+        } else {
+            assertNotNull(response);
+            try {
+                assertEquals(expected, response.status());
+            } finally {
+                response.release();
+            }
+        }
+    }
+
+    @Test
+    void nullMessageExceptionReturnsGeneric500() {
+        assertGenericError(new RuntimeException());
+    }
+
+    @Test
+    void exceptionMessageIsNotExposedToTheClient() {
+        assertGenericError(new RuntimeException("private server diagnostic"));
+    }
+
+    private void assertGenericError(Throwable error) {
+        channel.writeInbound(request("/exception", "body"));
+        channel.pipeline().fireExceptionCaught(error);
+        FullHttpResponse response = channel.readOutbound();
+        assertNotNull(response);
+        try {
+            assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, response.status());
+            assertEquals("Internal Server Error", response.content().toString(CharsetUtil.UTF_8));
+        } finally {
+            response.release();
+        }
+        assertFalse(channel.isActive());
+        assertEquals(1, events.size());
+        assertEquals(500, events.getFirst().status());
+        assertEquals(0, server.metrics.activeRequests());
+    }
+
     private static FullHttpRequest request(String path, String body) {
         ByteBuf buffer = PooledByteBufAllocator.DEFAULT.directBuffer();
         buffer.writeCharSequence(body, CharsetUtil.UTF_8);
@@ -255,6 +336,12 @@ class RequestOwnershipTest {
         final ShortLeaseSpace space = new ShortLeaseSpace();
         Context last;
         boolean failQueue;
+        CorsConfig cors;
+
+        @Override
+        public CorsConfig getCorsConfig(FullHttpRequest request) {
+            return cors;
+        }
 
         QueueServer() throws Exception {
             var field = RestServer.class.getDeclaredField("sp");

--- a/modules/qrest/src/test/java/org/jpos/qrest/RequestOwnershipTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/RequestOwnershipTest.java
@@ -1,0 +1,288 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.qrest;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.*;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+import org.jpos.core.SimpleConfiguration;
+import org.jpos.qrest.evt.QRestAccess;
+import org.jpos.space.TSpace;
+import org.jpos.transaction.Context;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RequestOwnershipTest {
+    private final List<QRestAccess> events = new ArrayList<>();
+    private SimpleMeterRegistry registry;
+    private QueueServer server;
+    private RestSession session;
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        registry = new SimpleMeterRegistry();
+        server = new QueueServer();
+        server.setName("ownership-test");
+        Properties props = new Properties();
+        props.setProperty("queue", "REQUESTS");
+        props.setProperty("request-timeout", "1");
+        server.setConfiguration(new SimpleConfiguration(props));
+        session = new RestSession(server) {
+            @Override
+            protected void emitAccessLog(QRestAccess event, UUID traceId) {
+                events.add(event);
+            }
+        };
+        channel = new EmbeddedChannel(session);
+        channel.freezeTime();
+    }
+
+    @AfterEach
+    void tearDown() {
+        channel.finishAndReleaseAll();
+        registry.close();
+    }
+
+    @Test
+    void aggregatedPooledBodyIsReleasedBeforeTheContextCanExpire() throws Exception {
+        channel.pipeline().addFirst(new HttpObjectAggregator(1024));
+        ByteBuf first = PooledByteBufAllocator.DEFAULT.directBuffer().writeBytes("hello ".getBytes());
+        ByteBuf second = PooledByteBufAllocator.DEFAULT.directBuffer().writeBytes("world".getBytes());
+        DefaultHttpRequest head = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/aggregate");
+        HttpUtil.setTransferEncodingChunked(head, true);
+        channel.writeInbound(head, new DefaultHttpContent(first), new DefaultLastHttpContent(second));
+        assertEquals(0, first.refCnt());
+        assertEquals(0, second.refCnt());
+        FullHttpRequest detached = server.last.get(Constants.REQUEST);
+        assertFalse(detached.content().isDirect());
+        assertEquals("hello world", detached.content().toString(CharsetUtil.UTF_8));
+        // Exercise the actual RestServer.queue path, with a short Space lease.
+        assertEquals(60000L, server.space.requestedLease);
+        Thread.sleep(20);
+        assertNull(server.space.rdp("REQUESTS"));
+        assertTrue(channel.isActive(), "expiry must not require a disconnect to free pooled storage");
+        channel.advanceTimeBy(2, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+        assertFalse(channel.isActive());
+        assertEquals(1, events.size());
+        assertNull(events.getFirst().status());
+        assertEquals(0, server.metrics.activeRequests());
+        assertTrue(channel.attr(RestSession.PENDING).get().isEmpty());
+    }
+
+    @Test
+    void disconnectAndHandlerRemovalDoNotInvalidateAPickedUpRequest() {
+        server.space.lease = 60000L;
+        FullHttpRequest source = request("/body", "payload");
+        source.headers().set("Authorization", "Bearer test-credential");
+        source.trailingHeaders().set("X-Trailer", "value");
+        channel.writeInbound(source);
+        Context ctx = server.space.inp("REQUESTS");
+        assertNotNull(ctx);
+        FullHttpRequest detached = ctx.get(Constants.REQUEST);
+        assertEquals(0, source.refCnt());
+        source.headers().set("Authorization", "changed");
+        channel.pipeline().remove(session);
+        channel.close();
+        assertEquals("payload", detached.content().toString(CharsetUtil.UTF_8));
+        assertEquals("Bearer test-credential", detached.headers().get("Authorization"));
+        assertEquals("value", detached.trailingHeaders().get("X-Trailer"));
+        assertFalse(detached.toString().contains("test-credential"));
+        FullHttpResponse response = response();
+        ctx.put(Constants.RESPONSE, response);
+        new SendResponse().commit(1, ctx);
+        assertEquals(0, response.refCnt(), "late response is not handed to a closed channel");
+        assertEquals("payload", detached.content().toString(CharsetUtil.UTF_8));
+        assertEquals(1, events.size());
+        assertEquals(0, server.metrics.activeRequests());
+    }
+
+    @Test
+    void participantCanReadWhileTheChannelCloses() throws Exception {
+        server.space.lease = 60000L;
+        FullHttpRequest source = request("/concurrent-read", "still readable");
+        channel.writeInbound(source);
+        Context ctx = server.space.inp("REQUESTS");
+        FullHttpRequest detached = ctx.get(Constants.REQUEST);
+        CyclicBarrier start = new CyclicBarrier(2);
+        try (var workers = Executors.newSingleThreadExecutor()) {
+            var read = workers.submit(() -> {
+                start.await();
+                for (int i = 0; i < 1000; i++)
+                    assertEquals("still readable", detached.content().toString(CharsetUtil.UTF_8));
+                return detached.content().toString(CharsetUtil.UTF_8);
+            });
+            start.await(5, TimeUnit.SECONDS);
+            channel.close();
+            assertEquals("still readable", read.get(5, TimeUnit.SECONDS));
+        }
+        assertEquals(0, source.refCnt());
+        assertEquals(1, events.size());
+    }
+
+    @Test
+    void successfulRequestsCancelTheirDeadlinesAndKeepTheirOwnAccessState() {
+        channel.writeInbound(request("/first", "one"));
+        Context first = server.last;
+        channel.writeInbound(request("/second", "two"));
+        Context second = server.last;
+        first.put(Constants.RESPONSE, response());
+        second.put(Constants.RESPONSE, response());
+        new SendResponse().commit(1, first);
+        new SendResponse().abort(2, second);
+        assertEquals(List.of("/first", "/second"), events.stream().map(QRestAccess::path).toList());
+        assertEquals(0, server.metrics.activeRequests());
+        channel.advanceTimeBy(2, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+        assertTrue(channel.isActive(), "completed requests must not close a reused connection");
+        assertEquals(2, events.size());
+    }
+
+    @Test
+    void handlerRemovalCompletesEveryOutstandingRequestOnce() {
+        channel.writeInbound(request("/first", "one"), request("/second", "two"));
+        channel.pipeline().remove(session);
+        assertEquals(2, events.size());
+        assertEquals(0, server.metrics.activeRequests());
+        channel.close();
+        channel.advanceTimeBy(2, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+        assertEquals(2, events.size());
+    }
+
+    @Test
+    void responseWriteFailureIsNotLoggedAsSuccess() {
+        channel.pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                ReferenceCountUtil.release(msg);
+                promise.setFailure(new IllegalStateException("write failed"));
+            }
+        });
+        channel.writeInbound(request("/failure", "body"));
+        FullHttpResponse response = response();
+        server.last.put(Constants.RESPONSE, response);
+        new SendResponse().commit(1, server.last);
+        assertEquals(0, response.refCnt());
+        assertEquals(1, events.size());
+        assertNull(events.getFirst().status());
+        assertEquals(0, server.metrics.activeRequests());
+    }
+
+    @Test
+    void concurrentCompletionRecordsOneAccessAndOneMetric() throws Exception {
+        channel.writeInbound(request("/race", "body"));
+        Context ctx = server.last;
+        RestAccessState state = RestSession.accessState(ctx);
+        ChannelHandlerContext ch = ctx.get(Constants.SESSION);
+        CyclicBarrier start = new CyclicBarrier(2);
+        try (var workers = Executors.newFixedThreadPool(2)) {
+            var success = workers.submit(() -> {
+                start.await();
+                return RestSession.completeAccess(ch, state, 200, 0L);
+            });
+            var disconnect = workers.submit(() -> {
+                start.await();
+                return RestSession.completeAccess(ch, state, null, null);
+            });
+            assertNotEquals(success.get(5, TimeUnit.SECONDS), disconnect.get(5, TimeUnit.SECONDS));
+        }
+        assertEquals(1, events.size());
+        assertEquals(0, server.metrics.activeRequests());
+    }
+
+    @Test
+    void enqueueFailureReleasesTransportAndCompletesAccess() {
+        server.failQueue = true;
+        FullHttpRequest source = request("/enqueue-failure", "body");
+        channel.writeInbound(source);
+        assertEquals(0, source.refCnt());
+        assertEquals(1, events.size());
+        assertEquals(500, events.getFirst().status());
+        assertEquals(0, server.metrics.activeRequests());
+    }
+
+    private static FullHttpRequest request(String path, String body) {
+        ByteBuf buffer = PooledByteBufAllocator.DEFAULT.directBuffer();
+        buffer.writeCharSequence(body, CharsetUtil.UTF_8);
+        FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, path, buffer);
+        request.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+        return request;
+    }
+
+    private static FullHttpResponse response() {
+        return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+          PooledByteBufAllocator.DEFAULT.directBuffer().writeByte(1));
+    }
+
+    private class QueueServer extends RestServer {
+        final QRestMetrics metrics = new QRestMetrics(registry, "ownership-test", QRestMetrics.PathLabel.ROUTE, 100);
+        final ShortLeaseSpace space = new ShortLeaseSpace();
+        Context last;
+        boolean failQueue;
+
+        QueueServer() throws Exception {
+            var field = RestServer.class.getDeclaredField("sp");
+            field.setAccessible(true);
+            field.set(this, space);
+        }
+
+        @Override
+        public void queue(FullHttpRequest request, Context ctx) {
+            if (failQueue)
+                throw new IllegalStateException("queue failed");
+            last = ctx;
+            super.queue(request, ctx);
+        }
+
+        @Override
+        QRestMetrics getMetrics() {
+            return metrics;
+        }
+    }
+
+    private static class ShortLeaseSpace extends TSpace<String, Context> {
+        long lease = 1L;
+        long requestedLease;
+        @Override
+        public void out(String key, Context value, long timeout) {
+            requestedLease = timeout;
+            super.out(key, value, lease);
+        }
+    }
+}

--- a/modules/qrest/src/test/java/org/jpos/qrest/RestSessionTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/RestSessionTest.java
@@ -163,7 +163,8 @@ class RestSessionTest {
         ctx.put(Constants.RESPONSE, new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
         new SendResponse().commit(1L, ctx);
         drainOutbound();
-        assertEquals(0, queued.refCnt(), "SendResponse must release the wrapped request");
+        assertEquals(0, request.refCnt(), "the pooled transport request must already be released");
+        assertEquals(1, queued.refCnt(), "the detached heap snapshot follows the Context GC lifetime");
     }
 
     @Test

--- a/modules/qrest/src/test/java/org/jpos/qrest/SendResponseTest.java
+++ b/modules/qrest/src/test/java/org/jpos/qrest/SendResponseTest.java
@@ -46,6 +46,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.netty.buffer.PooledByteBufAllocator;
 
 class SendResponseTest {
     private SendResponse participant;
@@ -173,6 +175,51 @@ class SendResponseTest {
         FullHttpResponse outbound = channel.readOutbound();
         if (outbound != null)
             outbound.release();
+    }
+
+    @Test
+    void missingResponseProduces404AndReleasesRequest() {
+        FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/missing");
+        Context ctx = new Context();
+        ctx.put(Constants.SESSION, channelHandlerContext);
+        ctx.put(Constants.REQUEST, request);
+        participant.commit(30, ctx);
+        assertEquals(0, request.refCnt());
+        FullHttpResponse response = channel.readOutbound();
+        assertEquals(HttpResponseStatus.NOT_FOUND, response.status());
+        response.release();
+    }
+
+    @Test
+    void responseConstructionFailureStillReleasesRequest() {
+        FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/failure");
+        Context ctx = createContext(request);
+        // Dispose the response supplied by the helper before replacing it.
+        ((FullHttpResponse) ctx.get(Constants.RESPONSE)).release();
+        ctx.put(Constants.RESPONSE, new Response(HttpResponseStatus.OK, null) {
+            @Override
+            public Object body() {
+                throw new IllegalArgumentException("cannot construct response");
+            }
+        });
+        assertThrows(IllegalArgumentException.class, () -> participant.commit(31, ctx));
+        assertEquals(0, request.refCnt());
+    }
+
+    @Test
+    void headerFailureReleasesBothRequestAndUnsentResponse() throws Exception {
+        participant.setConfiguration(new org.jpos.core.SimpleConfiguration(
+          new java.util.Properties() {{ setProperty("content-type", "invalid\r\nheader"); }}));
+        FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/headers");
+        Context ctx = createContext(request);
+        ((FullHttpResponse) ctx.get(Constants.RESPONSE)).release();
+        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+          PooledByteBufAllocator.DEFAULT.directBuffer().writeByte(1));
+        ctx.put(Constants.RESPONSE, response);
+        assertThrows(IllegalArgumentException.class, () -> participant.abort(32, ctx));
+        assertEquals(0, request.refCnt());
+        assertEquals(0, response.refCnt());
+        assertNull(channel.readOutbound());
     }
 
     private Context createContext(FullHttpRequest request) {


### PR DESCRIPTION
## Summary

Closes #401.

- Detach aggregated HTTP requests at the QRest ingress boundary: copy the readable body into a Java byte array, copy headers/trailers/decoder result, and release the original Netty request in a finally block before returning from channelRead.
- Preserve the FullHttpRequest interface and credential-masked LoggeableHttpRequest rendering. Queued snapshots use an unreleasable **unpooled heap** view whose lifetime is managed by GC with the Context; no pooled/direct storage is retained across the Space lease.
- Share one response helper between commit and abort. Its cleanup covers response construction, header processing and sending, and releases response buffers when construction fails or ownership has not been handed to Netty.
- Track access state per Context plus a channel pending set, with synchronized, once-only completion. Complete on the write future, channel close, handler removal or response timeout; failed writes are not recorded as successful responses. Use Context-specific route tagging in Router and Q2Info.
- Add a request-timeout (seconds), defaulting to timeout (300 seconds by default), which closes an unanswered connection and completes pending access state. Successful completion cancels the timer; zero disables the per-request timer. Error responses no longer depend on a non-null exception message or an initialized protocol-version attribute.

## Ownership design / compatibility

This deliberately differs from releasing a channel-held request on disconnect: a TM participant may still be reading that request. There is no generally available QRest transaction-completion hook that makes disconnect-driven release safe without a core/deployment change.

Instead, this self-contained fix pays one bounded body copy (maxContentLength, 512 KiB by default). The original pooled allocation is released deterministically even when the Space entry expires, SendResponse never runs, or queueing throws. The detached heap data remains valid for any participant still holding the Context, including after disconnect. This is not an unreleasable wrapper over pooled memory.

- The 60-second Space lease is unchanged. The response-wait timer is separate and does not claim to detect queue pickup, cancel transactions, or prevent a queued transaction from executing after client disconnection.
- retain/release on QRest-created heap snapshots do not govern their lifetime. Ordinary application-created LoggeableHttpRequest wrappers still delegate reference counting. Explicit copies made by participants follow the rules of their backing buffers.
- The new per-request deadline is not extended by subsequent keep-alive traffic. Configure request-timeout for legitimate long-running requests. It closes the connection without fabricating an HTTP response/status.
- Per-request tracking prevents overwritten audit state, but this PR does not add HTTP/1.1 pipelining response ordering.
- A missing RESPONSE already produces a 404 (or the transaction-failure status); preserve and test that behavior rather than treating it as a null-response leak.

## Tests and verification

Java 26.0.2-amzn and Gradle 9.7.1 selected from .sdkmanrc.

- `./gradlew :modules:qrest:test :modules:qrest:javadoc`
- Final `./gradlew check assemble :modules:qrest:javadoc`: **BUILD SUCCESSFUL**.
- Initial full-run aggregate reports: **391 tests, zero failures/errors, 2 skipped**; QRest: **188 tests, zero failures/errors/skips**.
- PostgreSQL-backed MiniGL/SeqNo and Kafka suites passed in the full run. The final retry reused passing unchanged tasks after fixing a test-clock dependency; no exclusions added.
- Regression tests cover actual HTTP aggregation over pooled direct components and Space lease expiry, detached body/header/trailer integrity, concurrent participant reads during disconnect, multiple pending requests, handler removal, deadline cancellation, competing access completion, queue/write failures, response construction/header failures, and missing-response fallback.
- Netty EmbeddedChannel time is frozen/advanced explicitly for deadline assertions; ownership is verified with reference counts rather than sampled GC leak warnings.
- `git diff --check` passed.

The initial full build emitted two pre-existing non-fatal Javadoc diagnostics in unchanged files: GroovyRequestListener.java (`h1` heading) and qrest-crud/CRUD.java (unexpected closing `p`). The repository configures Javadoc failOnError=false; QRest Javadoc itself passed. No production-load benchmark or heap-copy throughput benchmark was performed. Modules disabled in settings.gradle are outside the standard build.


## Review follow-up (0c4191ad0)

Removed the redundant Context monitor and unused QRestMetrics.requestFailed helper; the production exception-path metrics remain covered by RestSession integration tests. Added ownership comments, clarified timeout behavior, and documented the fixed client-visible HTTP 500 body in the guide and pending ChangeLog entry. Added three CORS ownership regressions and two generic-error-body regressions; removed the obsolete helper-only unit test.

`./gradlew :modules:qrest:check :modules:qrest:assemble :modules:qrest:javadoc` passed with Java 26.0.2-amzn / Gradle 9.7.1: **192 QRest tests, zero failures/errors/skips**. `git diff --check` passed. The unchanged non-QRest suites were not rerun for this review-only follow-up; the full-run results above refer to the initial implementation.
